### PR TITLE
using fcl namespace in aliases and imports

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -41,10 +41,7 @@ module.exports = ({ config: defaultConfig }) => {
     ...defaultConfig,
     resolve: {
       ...defaultConfig.resolve,
-      alias: {
-        "@figshare/fcl": "@figshare/fcl/src",
-        "@figshare/ui": "@figshare/ui/src",
-      },
+      alias: { "@figshare/fcl": "@figshare/fcl/src" },
       modules: ["node_modules"],
     },
     plugins: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -30,7 +30,7 @@ module.exports = {
   moduleNameMapper: {
     "\\.css$": require.resolve("identity-obj-proxy"),
     "file-loader!*": "<rootDir>/scripts/tests/fileTransformer.js",
-    "@figshare/ui/(.*)": "@figshare/ui/src/$1",
+    "@figshare/fcl/(.*)": "@figshare/fcl/src/$1",
   },
   testEnvironment: "jsdom",
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1684,14 +1684,11 @@
     "@figshare/fcl": {
       "version": "file:packages/ui",
       "requires": {
-        "@joplin/turndown-plugin-gfm": "1.0.45",
         "classnames": "2.3.2",
         "draft-js": "0.10.0",
         "draft-js-export-html": "1.4.1",
         "draft-js-import-html": "1.4.1",
-        "marked": "4.0.18",
-        "react-datepicker": "4.8.0",
-        "turndown": "7.1.1"
+        "react-datepicker": "4.8.0"
       }
     },
     "@figshare/style-guide": {
@@ -1771,19 +1768,6 @@
         "loader-utils": "2.0.4",
         "moment": "2.29.4",
         "style-loader": "2.0.0"
-      }
-    },
-    "@figshare/ui": {
-      "version": "file:packages/ui",
-      "requires": {
-        "@joplin/turndown-plugin-gfm": "1.0.45",
-        "classnames": "2.3.2",
-        "draft-js": "0.10.0",
-        "draft-js-export-html": "1.4.1",
-        "draft-js-import-html": "1.4.1",
-        "marked": "4.0.18",
-        "react-datepicker": "4.8.0",
-        "turndown": "7.1.1"
       }
     },
     "@figspec/components": {
@@ -2812,11 +2796,6 @@
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0"
       }
-    },
-    "@joplin/turndown-plugin-gfm": {
-      "version": "1.0.45",
-      "resolved": "https://registry.npmjs.org/@joplin/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.45.tgz",
-      "integrity": "sha512-RUQfMrFqFp2wB0mOZPGOTq6LVUVBOhQg87+ecv1+qF2gTHZm3jQd77iV5Eddbg2WjCj06eCG99et3kdPf0YwVw=="
     },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
@@ -15531,11 +15510,6 @@
         "domelementtype": "^2.2.0"
       }
     },
-    "domino": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
-      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
-    },
     "domutils": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
@@ -22574,11 +22548,6 @@
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
       "dev": true
     },
-    "marked": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.18.tgz",
-      "integrity": "sha512-wbLDJ7Zh0sqA0Vdg6aqlbT+yPxqLblpAZh1mK2+AO2twQkPywvvqQNfEPVwSSRjZ7dZcdeVBIAgiO7MMp3Dszw=="
-    },
     "mathml-tag-names": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -28922,14 +28891,6 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
-      }
-    },
-    "turndown": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.1.1.tgz",
-      "integrity": "sha512-BEkXaWH7Wh7e9bd2QumhfAXk5g34+6QUmmWx+0q6ThaVOLuLUqsnkq35HQ5SBHSaxjSfSM7US5o4lhJNH7B9MA==",
-      "requires": {
-        "domino": "^2.1.6"
       }
     },
     "tweetnacl": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
   },
   "dependencies": {
     "@figshare/tools": "*",
-    "@figshare/ui": "file:./packages/ui",
     "@figshare/fcl": "file:./packages/ui",
     "@loadable/component": "5.15.3",
     "core-js": "3.26.1",

--- a/packages/ui/src/a11y/linking/provider.jsx
+++ b/packages/ui/src/a11y/linking/provider.jsx
@@ -1,6 +1,6 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
-import isFunction from "@figshare/ui/helpers/utils/isFunction";
+import isFunction from "@figshare/fcl/helpers/utils/isFunction";
 
 import Context from "./context";
 import { mutations, reading } from "./storage";

--- a/packages/ui/src/input/search/constants.js
+++ b/packages/ui/src/input/search/constants.js
@@ -1,7 +1,7 @@
-import CancelMedium from "@figshare/ui/icons/cancel/medium";
-import CancelLarge from "@figshare/ui/icons/cancel/large";
-import SearchMedium from "@figshare/ui/icons/search/medium";
-import SearchLarge from "@figshare/ui/icons/search/large";
+import CancelMedium from "@figshare/fcl/icons/cancel/medium";
+import CancelLarge from "@figshare/fcl/icons/cancel/large";
+import SearchMedium from "@figshare/fcl/icons/search/medium";
+import SearchLarge from "@figshare/fcl/icons/search/large";
 
 
 export const sizes = {

--- a/packages/ui/src/input/search/index.test.jsx
+++ b/packages/ui/src/input/search/index.test.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { IconButton } from "@figshare/ui/button";
+import { IconButton } from "@figshare/fcl/button";
 import { shallow } from "enzyme";
 
 import SearchForm from "./index";

--- a/packages/ui/src/overlay/overlay.jsx
+++ b/packages/ui/src/overlay/overlay.jsx
@@ -1,7 +1,7 @@
 import classnames from "classnames";
 import React, { Component, createContext } from "react";
 import PropTypes from "prop-types";
-import Cancel from "@figshare/ui/icons/cancel/large";
+import Cancel from "@figshare/fcl/icons/cancel/large";
 
 import { IconButton } from "../button";
 import FocusTrap from "../helpers/focusTrap";

--- a/packages/ui/src/overlay/overlay.test.jsx
+++ b/packages/ui/src/overlay/overlay.test.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { mount } from "enzyme";
-import { IconButton } from "@figshare/ui/button";
-import RenderInPortal from "@figshare/ui/helpers/renderInPortal";
+import { IconButton } from "@figshare/fcl/button";
+import RenderInPortal from "@figshare/fcl/helpers/renderInPortal";
 
 import Overlay from "./overlay";
 

--- a/packages/ui/src/popup/components/trigger/index.test.jsx
+++ b/packages/ui/src/popup/components/trigger/index.test.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { shallow } from "enzyme";
-import { Button } from "@figshare/ui/button";
+import { Button } from "@figshare/fcl/button";
 
 import Trigger from "./index";
 

--- a/packages/ui/src/textEditor/components/linkModal/index.jsx
+++ b/packages/ui/src/textEditor/components/linkModal/index.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/no-autofocus */
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Button } from "@figshare/ui/button";
+import { Button } from "@figshare/fcl/button";
 
 import { findEntityType } from "../../utils";
 

--- a/packages/ui/src/textEditor/components/linkModal/index.test.jsx
+++ b/packages/ui/src/textEditor/components/linkModal/index.test.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { mount } from "enzyme";
 import { EditorState } from "draft-js";
-import { Button } from "@figshare/ui/button";
+import { Button } from "@figshare/fcl/button";
 
 import { onConvertHTMLtoDraft } from "../../utils";
 

--- a/packages/ui/src/textEditor/components/toolbar/index.jsx
+++ b/packages/ui/src/textEditor/components/toolbar/index.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import Resize from "@figshare/ui/icons/editor/resize";
+import Resize from "@figshare/fcl/icons/editor/resize";
 
 import ToolbarButton from "../toolbarButton";
 import {

--- a/packages/ui/src/textEditor/utils/constants.js
+++ b/packages/ui/src/textEditor/utils/constants.js
@@ -1,4 +1,4 @@
-import icons from "@figshare/ui/icons/editor";
+import icons from "@figshare/fcl/icons/editor";
 
 
 export const controlButtons = [

--- a/packages/ui/src/toggletip/components/content/index.jsx
+++ b/packages/ui/src/toggletip/components/content/index.jsx
@@ -1,10 +1,10 @@
 import classnames from "classnames";
 import PropTypes from "prop-types";
 import React, { Component } from "react";
-import FocusTrap from "@figshare/ui/helpers/focusTrap";
-import { Content as PopupContent } from "@figshare/ui/popup";
-import { GenericButton } from "@figshare/ui/button";
-import Cancel from "@figshare/ui/icons/cancel/small";
+import FocusTrap from "@figshare/fcl/helpers/focusTrap";
+import { Content as PopupContent } from "@figshare/fcl/popup";
+import { GenericButton } from "@figshare/fcl/button";
+import Cancel from "@figshare/fcl/icons/cancel/small";
 
 import styles from "./index.css";
 

--- a/packages/ui/src/toggletip/components/content/index.test.jsx
+++ b/packages/ui/src/toggletip/components/content/index.test.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { mount } from "enzyme";
-import FocusTrap from "@figshare/ui/helpers/focusTrap";
-import { Content as PopupContent } from "@figshare/ui/popup";
-import Cancel from "@figshare/ui/icons/cancel/small";
+import FocusTrap from "@figshare/fcl/helpers/focusTrap";
+import { Content as PopupContent } from "@figshare/fcl/popup";
+import Cancel from "@figshare/fcl/icons/cancel/small";
 
 import Content from "./index";
 

--- a/packages/ui/src/toggletip/components/trigger/index.jsx
+++ b/packages/ui/src/toggletip/components/trigger/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
-import { Trigger as PopupTrigger } from "@figshare/ui/popup";
-import { Button, IconButton, GenericButton } from "@figshare/ui/button";
+import { Trigger as PopupTrigger } from "@figshare/fcl/popup";
+import { Button, IconButton, GenericButton } from "@figshare/fcl/button";
 
 
 const mapping = {

--- a/packages/ui/src/toggletip/components/trigger/index.test.jsx
+++ b/packages/ui/src/toggletip/components/trigger/index.test.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { mount } from "enzyme";
-import { Trigger as PopupTrigger } from "@figshare/ui/popup";
-import { Button, GenericButton, IconButton } from "@figshare/ui/button";
-import Info from "@figshare/ui/icons/info/medium";
+import { Trigger as PopupTrigger } from "@figshare/fcl/popup";
+import { Button, GenericButton, IconButton } from "@figshare/fcl/button";
+import Info from "@figshare/fcl/icons/info/medium";
 
 import Trigger from "./index";
 

--- a/packages/ui/src/toggletip/index.jsx
+++ b/packages/ui/src/toggletip/index.jsx
@@ -1,7 +1,7 @@
 import PropTypes from "prop-types";
 import React, { Component, Children } from "react";
-import Popup from "@figshare/ui/popup";
-import uidGenerator from "@figshare/ui/a11y/context/uidGenerator";
+import Popup from "@figshare/fcl/popup";
+import uidGenerator from "@figshare/fcl/a11y/context/uidGenerator";
 
 
 const uid = uidGenerator();

--- a/stories/a11y/directConsumerAccess.stories.jsx
+++ b/stories/a11y/directConsumerAccess.stories.jsx
@@ -1,8 +1,8 @@
 import PropTypes from "prop-types";
 import React, { Component } from "react";
-import { Button } from "@figshare/ui/button";
-import { withA11y } from "@figshare/ui/a11y/context";
-import { LinkingProvider, LinkingObject, LinkingReference, withLinkingContext } from "@figshare/ui/a11y/linking/index";
+import { Button } from "@figshare/fcl/button";
+import { withA11y } from "@figshare/fcl/a11y/context";
+import { LinkingProvider, LinkingObject, LinkingReference, withLinkingContext } from "@figshare/fcl/a11y/linking/index";
 
 // eslint-disable-next-line css-modules/no-unused-class
 import styles from "./storybook.stories.css";

--- a/stories/a11y/functionChildren.stories.jsx
+++ b/stories/a11y/functionChildren.stories.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Button } from "@figshare/ui/button";
-import { LinkingProvider, LinkingObject, LinkingReference } from "@figshare/ui/a11y/linking/index";
+import { Button } from "@figshare/fcl/button";
+import { LinkingProvider, LinkingObject, LinkingReference } from "@figshare/fcl/a11y/linking/index";
 
 // eslint-disable-next-line css-modules/no-unused-class
 import styles from "./storybook.stories.css";

--- a/stories/a11y/hoc.stories.jsx
+++ b/stories/a11y/hoc.stories.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Button } from "@figshare/ui/button";
-import { LinkingProvider, withLinkingObject, withLinkingReference } from "@figshare/ui/a11y/linking/index";
+import { Button } from "@figshare/fcl/button";
+import { LinkingProvider, withLinkingObject, withLinkingReference } from "@figshare/fcl/a11y/linking/index";
 
 // eslint-disable-next-line css-modules/no-unused-class
 import styles from "./storybook.stories.css";

--- a/stories/a11y/propComponent.stories.jsx
+++ b/stories/a11y/propComponent.stories.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import { Button } from "@figshare/ui/button";
-import { LinkingProvider, LinkingObject, LinkingReference } from "@figshare/ui/a11y/linking/index";
+import { Button } from "@figshare/fcl/button";
+import { LinkingProvider, LinkingObject, LinkingReference } from "@figshare/fcl/a11y/linking/index";
 
 // eslint-disable-next-line css-modules/no-unused-class
 import styles from "./storybook.stories.css";

--- a/stories/button/button/index.stories.mdx
+++ b/stories/button/button/index.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import Home from "@figshare/ui/icons/home/medium";
-import Button from "@figshare/ui/button/button";
+import Home from "@figshare/fcl/icons/home/medium";
+import Button from "@figshare/fcl/button/button";
 
 
 <Meta 

--- a/stories/button/genericButton/index.stories.mdx
+++ b/stories/button/genericButton/index.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import Home from "@figshare/ui/icons/home/medium";
-import GenericButton from "@figshare/ui/button/genericButton";
+import Home from "@figshare/fcl/icons/home/medium";
+import GenericButton from "@figshare/fcl/button/genericButton";
 
 
 <Meta 
@@ -42,8 +42,8 @@ or display a set of actions, close toghether or one after the other.
 
 ```jsx
 import React from "react";
-import Home from "@figshare/ui/icons/home";
-import { GenericButton } from "@figshare/ui/button";
+import Home from "@figshare/fcl/icons/home";
+import { GenericButton } from "@figshare/fcl/button";
 
 class MyButton extends React.Component {
   render() {

--- a/stories/button/iconButton/index.stories.mdx
+++ b/stories/button/iconButton/index.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import Home from "@figshare/ui/icons/home/medium";
-import IconButton from "@figshare/ui/button/iconButton";
+import Home from "@figshare/fcl/icons/home/medium";
+import IconButton from "@figshare/fcl/button/iconButton";
 
 
 <Meta 

--- a/stories/helpers/note.stories.jsx
+++ b/stories/helpers/note.stories.jsx
@@ -1,8 +1,8 @@
 import classnames from "classnames";
 import React from "react";
-import Eye from "@figshare/ui/icons/eye/visible/medium";
-import Info from "@figshare/ui/icons/info/medium";
-import Warning from "@figshare/ui/icons/warning/medium";
+import Eye from "@figshare/fcl/icons/eye/visible/medium";
+import Info from "@figshare/fcl/icons/info/medium";
+import Warning from "@figshare/fcl/icons/warning/medium";
 
 import styles from "./note.css";
 

--- a/stories/icons/figshare.stories.mdx
+++ b/stories/icons/figshare.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
-import FigshareLogo from "@figshare/ui/icons/figshare/logo";
-import FigshareText from "@figshare/ui/icons/figshare/text";
-import FigshareFullLogo from "@figshare/ui/icons/figshare/index";
+import FigshareLogo from "@figshare/fcl/icons/figshare/logo";
+import FigshareText from "@figshare/fcl/icons/figshare/text";
+import FigshareFullLogo from "@figshare/fcl/icons/figshare/index";
 
 
 export const Container = (props) => {
@@ -80,8 +80,8 @@ import FigshareFullLogo from "@figshare/fcl/icons/figshare/index";
 
 ## OrcID
 
-import Orcid from "@figshare/ui/icons/orcid/index";
-import OrcidSmall from "@figshare/ui/icons/orcid/small";
+import Orcid from "@figshare/fcl/icons/orcid/index";
+import OrcidSmall from "@figshare/fcl/icons/orcid/small";
 
 <Story
   name="OrcID"
@@ -107,7 +107,7 @@ import OrcidSmall from "@figshare/fcl/icons/orcid/small";
 
 ## Rss
 
-import Rss from "@figshare/ui/icons/rss/index";
+import Rss from "@figshare/fcl/icons/rss/index";
 
 <Story
   name="Rss"
@@ -131,11 +131,11 @@ import Rss from "@figshare/fcl/icons/rss/index";
 ## Social Media
 
 
-import Facebook from "@figshare/ui/icons/socialMedia/facebook";
-import Linkedin from "@figshare/ui/icons/socialMedia/linkedin";
-import Twitter from "@figshare/ui/icons/socialMedia/twitter";
-import TwitterInverted from "@figshare/ui/icons/socialMedia/twitter_inverted";
-import Vimeo from "@figshare/ui/icons/socialMedia/vimeo";
+import Facebook from "@figshare/fcl/icons/socialMedia/facebook";
+import Linkedin from "@figshare/fcl/icons/socialMedia/linkedin";
+import Twitter from "@figshare/fcl/icons/socialMedia/twitter";
+import TwitterInverted from "@figshare/fcl/icons/socialMedia/twitter_inverted";
+import Vimeo from "@figshare/fcl/icons/socialMedia/vimeo";
 
 <Story
   name="Social Media"

--- a/stories/icons/icons.stories.mdx
+++ b/stories/icons/icons.stories.mdx
@@ -19,14 +19,14 @@ A comprehensive, wide range of icons, useful for visually representing interacti
 
 ## Caret
 
-import CaretRightSmall from "@figshare/ui/icons/caret/right/small";
-import CaretDownSmall from "@figshare/ui/icons/caret/down/small";
-import CaretLeftSmall from "@figshare/ui/icons/caret/left/small";
-import CaretUpSmall from "@figshare/ui/icons/caret/up/small";
-import CaretRightMedium from "@figshare/ui/icons/caret/right/medium";
-import CaretDownMedium from "@figshare/ui/icons/caret/down/medium";
-import CaretLeftMedium from "@figshare/ui/icons/caret/left/medium";
-import CaretUpMedium from "@figshare/ui/icons/caret/up/medium";
+import CaretRightSmall from "@figshare/fcl/icons/caret/right/small";
+import CaretDownSmall from "@figshare/fcl/icons/caret/down/small";
+import CaretLeftSmall from "@figshare/fcl/icons/caret/left/small";
+import CaretUpSmall from "@figshare/fcl/icons/caret/up/small";
+import CaretRightMedium from "@figshare/fcl/icons/caret/right/medium";
+import CaretDownMedium from "@figshare/fcl/icons/caret/down/medium";
+import CaretLeftMedium from "@figshare/fcl/icons/caret/left/medium";
+import CaretUpMedium from "@figshare/fcl/icons/caret/up/medium";
 
 <Story name="Caret">
   <CaretRightSmall className={styles.icon} />
@@ -63,14 +63,14 @@ import CaretUpMedium from "@figshare/fcl/icons/caret/up/medium";
 ---
 ## Chevron
 
-import ChevronRightSmall from "@figshare/ui/icons/chevron/right/small";
-import ChevronDownSmall from "@figshare/ui/icons/chevron/down/small";
-import ChevronLeftSmall from "@figshare/ui/icons/chevron/left/small";
-import ChevronUpSmall from "@figshare/ui/icons/chevron/up/small";
-import ChevronRightMedium from "@figshare/ui/icons/chevron/right/medium";
-import ChevronDownMedium from "@figshare/ui/icons/chevron/down/medium";
-import ChevronLeftMedium from "@figshare/ui/icons/chevron/left/medium";
-import ChevronUpMedium from "@figshare/ui/icons/chevron/up/medium";
+import ChevronRightSmall from "@figshare/fcl/icons/chevron/right/small";
+import ChevronDownSmall from "@figshare/fcl/icons/chevron/down/small";
+import ChevronLeftSmall from "@figshare/fcl/icons/chevron/left/small";
+import ChevronUpSmall from "@figshare/fcl/icons/chevron/up/small";
+import ChevronRightMedium from "@figshare/fcl/icons/chevron/right/medium";
+import ChevronDownMedium from "@figshare/fcl/icons/chevron/down/medium";
+import ChevronLeftMedium from "@figshare/fcl/icons/chevron/left/medium";
+import ChevronUpMedium from "@figshare/fcl/icons/chevron/up/medium";
 
 <Story name="Chevron">
   <ChevronRightSmall className={styles.icon} />
@@ -97,14 +97,14 @@ import ChevronUpMedium from "@figshare/fcl/icons/chevron/up/medium";
 ---
 ## DoubleChevron
 
-import DoubleChevronRightSmall from "@figshare/ui/icons/doubleChevron/right/small";
-import DoubleChevronDownSmall from "@figshare/ui/icons/doubleChevron/down/small";
-import DoubleChevronLeftSmall from "@figshare/ui/icons/doubleChevron/left/small";
-import DoubleChevronUpSmall from "@figshare/ui/icons/doubleChevron/up/small";
-import DoubleChevronRightMedium from "@figshare/ui/icons/doubleChevron/right/medium";
-import DoubleChevronDownMedium from "@figshare/ui/icons/doubleChevron/down/medium";
-import DoubleChevronLeftMedium from "@figshare/ui/icons/doubleChevron/left/medium";
-import DoubleChevronUpMedium from "@figshare/ui/icons/doubleChevron/up/medium";
+import DoubleChevronRightSmall from "@figshare/fcl/icons/doubleChevron/right/small";
+import DoubleChevronDownSmall from "@figshare/fcl/icons/doubleChevron/down/small";
+import DoubleChevronLeftSmall from "@figshare/fcl/icons/doubleChevron/left/small";
+import DoubleChevronUpSmall from "@figshare/fcl/icons/doubleChevron/up/small";
+import DoubleChevronRightMedium from "@figshare/fcl/icons/doubleChevron/right/medium";
+import DoubleChevronDownMedium from "@figshare/fcl/icons/doubleChevron/down/medium";
+import DoubleChevronLeftMedium from "@figshare/fcl/icons/doubleChevron/left/medium";
+import DoubleChevronUpMedium from "@figshare/fcl/icons/doubleChevron/up/medium";
 
 <Story name="DoubleChevron">
   <DoubleChevronRightSmall className={styles.icon} />
@@ -131,10 +131,10 @@ import DoubleChevronUpMedium from "@figshare/fcl/icons/doubleChevron/up/medium";
 ---
 ## Angle
 
-import AngleRight from "@figshare/ui/icons/angle/right";
-import AngleDown from "@figshare/ui/icons/angle/down";
-import AngleLeft from "@figshare/ui/icons/angle/left";
-import AngleUp from "@figshare/ui/icons/angle/up";
+import AngleRight from "@figshare/fcl/icons/angle/right";
+import AngleDown from "@figshare/fcl/icons/angle/down";
+import AngleLeft from "@figshare/fcl/icons/angle/left";
+import AngleUp from "@figshare/fcl/icons/angle/up";
 
 <Story name="Angle">
   <AngleRight className={styles.icon} />
@@ -153,18 +153,18 @@ import AngleUp from "@figshare/fcl/icons/angle/up";
 ---
 ## Arrow
 
-import ArrowRightSmall from "@figshare/ui/icons/arrow/right/small";
-import ArrowDownSmall from "@figshare/ui/icons/arrow/down/small";
-import ArrowLeftSmall from "@figshare/ui/icons/arrow/left/small";
-import ArrowUpSmall from "@figshare/ui/icons/arrow/up/small";
-import ArrowRightMedium from "@figshare/ui/icons/arrow/right/medium";
-import ArrowDownMedium from "@figshare/ui/icons/arrow/down/medium";
-import ArrowLeftMedium from "@figshare/ui/icons/arrow/left/medium";
-import ArrowUpMedium from "@figshare/ui/icons/arrow/up/medium";
-import ArrowRightLarge from "@figshare/ui/icons/arrow/right/large";
-import ArrowDownLarge from "@figshare/ui/icons/arrow/down/large";
-import ArrowLeftLarge from "@figshare/ui/icons/arrow/left/large";
-import ArrowUpLarge from "@figshare/ui/icons/arrow/up/large";
+import ArrowRightSmall from "@figshare/fcl/icons/arrow/right/small";
+import ArrowDownSmall from "@figshare/fcl/icons/arrow/down/small";
+import ArrowLeftSmall from "@figshare/fcl/icons/arrow/left/small";
+import ArrowUpSmall from "@figshare/fcl/icons/arrow/up/small";
+import ArrowRightMedium from "@figshare/fcl/icons/arrow/right/medium";
+import ArrowDownMedium from "@figshare/fcl/icons/arrow/down/medium";
+import ArrowLeftMedium from "@figshare/fcl/icons/arrow/left/medium";
+import ArrowUpMedium from "@figshare/fcl/icons/arrow/up/medium";
+import ArrowRightLarge from "@figshare/fcl/icons/arrow/right/large";
+import ArrowDownLarge from "@figshare/fcl/icons/arrow/down/large";
+import ArrowLeftLarge from "@figshare/fcl/icons/arrow/left/large";
+import ArrowUpLarge from "@figshare/fcl/icons/arrow/up/large";
 
 <Story name="Arrow">
   <ArrowRightSmall className={styles.icon} />
@@ -199,8 +199,8 @@ import ArrowUpLarge from "@figshare/fcl/icons/arrow/up/large";
 ---
 ## Sort
 
-import SortUp from "@figshare/ui/icons/sort/up";
-import SortDown from "@figshare/ui/icons/sort/down";
+import SortUp from "@figshare/fcl/icons/sort/up";
+import SortDown from "@figshare/fcl/icons/sort/down";
 
 <Story name="Sort">
   <SortUp className={styles.icon} />
@@ -214,9 +214,9 @@ import SortDown from "@figshare/fcl/icons/sort/down";
 ---
 ## Expand
 
-import ExpandSmall from "@figshare/ui/icons/expand/small";
-import ExpandMedium from "@figshare/ui/icons/expand/medium";
-import ExpandLarge from "@figshare/ui/icons/expand/large";
+import ExpandSmall from "@figshare/fcl/icons/expand/small";
+import ExpandMedium from "@figshare/fcl/icons/expand/medium";
+import ExpandLarge from "@figshare/fcl/icons/expand/large";
 
 <Story name="Expand">
   <ExpandSmall className={styles.icon} />
@@ -232,9 +232,9 @@ import ExpandLarge from "@figshare/fcl/icons/expand/large";
 ---
 ## Collapse
 
-import CollapseSmall from "@figshare/ui/icons/collapse/small";
-import CollapseMedium from "@figshare/ui/icons/collapse/medium";
-import CollapseLarge from "@figshare/ui/icons/collapse/large";
+import CollapseSmall from "@figshare/fcl/icons/collapse/small";
+import CollapseMedium from "@figshare/fcl/icons/collapse/medium";
+import CollapseLarge from "@figshare/fcl/icons/collapse/large";
 
 <Story name="Collapse">
   <CollapseSmall className={styles.icon} />
@@ -251,9 +251,9 @@ import CollapseLarge from "@figshare/fcl/icons/collapse/large";
 ---
 ## CheckMark
 
-import CheckMarkSmall from "@figshare/ui/icons/checkMark/small";
-import CheckMarkMedium from "@figshare/ui/icons/checkMark/medium";
-import CheckMarkLarge from "@figshare/ui/icons/checkMark/large";
+import CheckMarkSmall from "@figshare/fcl/icons/checkMark/small";
+import CheckMarkMedium from "@figshare/fcl/icons/checkMark/medium";
+import CheckMarkLarge from "@figshare/fcl/icons/checkMark/large";
 
 <Story name="CheckMark">
   <CheckMarkSmall className={styles.icon} />
@@ -270,9 +270,9 @@ import CheckMarkLarge from "@figshare/fcl/icons/checkMark/large";
 ---
 ## Plus
 
-import PlusSmall from "@figshare/ui/icons/plus/small";
-import PlusMedium from "@figshare/ui/icons/plus/medium";
-import PlusLarge from "@figshare/ui/icons/plus/large";
+import PlusSmall from "@figshare/fcl/icons/plus/small";
+import PlusMedium from "@figshare/fcl/icons/plus/medium";
+import PlusLarge from "@figshare/fcl/icons/plus/large";
 
 <Story name="Plus">
   <PlusSmall className={styles.icon} />
@@ -289,9 +289,9 @@ import PlusLarge from "@figshare/fcl/icons/plus/large";
 ---
 ## Minus
 
-import MinusSmall from "@figshare/ui/icons/minus/small";
-import MinusMedium from "@figshare/ui/icons/minus/medium";
-import MinusLarge from "@figshare/ui/icons/minus/large";
+import MinusSmall from "@figshare/fcl/icons/minus/small";
+import MinusMedium from "@figshare/fcl/icons/minus/medium";
+import MinusLarge from "@figshare/fcl/icons/minus/large";
 
 <Story name="Minus">
   <MinusSmall className={styles.icon} />
@@ -308,9 +308,9 @@ import MinusLarge from "@figshare/fcl/icons/minus/large";
 ---
 ## Home
 
-import HomeSmall from "@figshare/ui/icons/home/small";
-import HomeMedium from "@figshare/ui/icons/home/medium";
-import HomeLarge from "@figshare/ui/icons/home/large";
+import HomeSmall from "@figshare/fcl/icons/home/small";
+import HomeMedium from "@figshare/fcl/icons/home/medium";
+import HomeLarge from "@figshare/fcl/icons/home/large";
 
 <Story name="Home">
   <HomeSmall className={styles.icon} />
@@ -327,9 +327,9 @@ import HomeLarge from "@figshare/fcl/icons/home/large";
 ---
 ## Lock
 
-import LockSmall from "@figshare/ui/icons/lock/small";
-import LockMedium from "@figshare/ui/icons/lock/medium";
-import LockLarge from "@figshare/ui/icons/lock/large";
+import LockSmall from "@figshare/fcl/icons/lock/small";
+import LockMedium from "@figshare/fcl/icons/lock/medium";
+import LockLarge from "@figshare/fcl/icons/lock/large";
 
 <Story name="Lock">
   <LockSmall className={styles.icon} />
@@ -346,9 +346,9 @@ import LockLarge from "@figshare/fcl/icons/lock/large";
 ---
 ## LockedFiles
 
-import LockedFilesSmall from "@figshare/ui/icons/lockedFiles/small";
-import LockedFilesMedium from "@figshare/ui/icons/lockedFiles/medium";
-import LockedFilesLarge from "@figshare/ui/icons/lockedFiles/large";
+import LockedFilesSmall from "@figshare/fcl/icons/lockedFiles/small";
+import LockedFilesMedium from "@figshare/fcl/icons/lockedFiles/medium";
+import LockedFilesLarge from "@figshare/fcl/icons/lockedFiles/large";
 
 <Story name="LockedFiles">
   <LockedFilesSmall className={styles.icon} />
@@ -367,9 +367,9 @@ import LockedFilesLarge from "@figshare/fcl/icons/lockedFiles/large";
 ---
 ## Cancel
 
-import CancelSmall from "@figshare/ui/icons/cancel/small";
-import CancelMedium from "@figshare/ui/icons/cancel/medium";
-import CancelLarge from "@figshare/ui/icons/cancel/large";
+import CancelSmall from "@figshare/fcl/icons/cancel/small";
+import CancelMedium from "@figshare/fcl/icons/cancel/medium";
+import CancelLarge from "@figshare/fcl/icons/cancel/large";
 
 <Story name="Cancel">
   <CancelSmall className={styles.icon} />
@@ -388,9 +388,9 @@ import CancelLarge from "@figshare/fcl/icons/cancel/large";
 ---
 ## Search
 
-import SearchSmall from "@figshare/ui/icons/search/small";
-import SearchMedium from "@figshare/ui/icons/search/medium";
-import SearchLarge from "@figshare/ui/icons/search/large";
+import SearchSmall from "@figshare/fcl/icons/search/small";
+import SearchMedium from "@figshare/fcl/icons/search/medium";
+import SearchLarge from "@figshare/fcl/icons/search/large";
 
 <Story name="Search">
   <SearchSmall className={styles.icon} />
@@ -407,12 +407,12 @@ import SearchLarge from "@figshare/fcl/icons/search/large";
 ---
 ## ViewType
 
-import ViewTypeThumbnailSmall from "@figshare/ui/icons/viewType/thumbnail/small";
-import ViewTypeThumbnailLarge from "@figshare/ui/icons/viewType/thumbnail/large";
-import ViewTypeListSmall from "@figshare/ui/icons/viewType/list/small";
-import ViewTypeListLarge from "@figshare/ui/icons/viewType/list/large";
-import ViewTypeFileSmall from "@figshare/ui/icons/viewType/file/small";
-import ViewTypeFileLarge from "@figshare/ui/icons/viewType/file/large";
+import ViewTypeThumbnailSmall from "@figshare/fcl/icons/viewType/thumbnail/small";
+import ViewTypeThumbnailLarge from "@figshare/fcl/icons/viewType/thumbnail/large";
+import ViewTypeListSmall from "@figshare/fcl/icons/viewType/list/small";
+import ViewTypeListLarge from "@figshare/fcl/icons/viewType/list/large";
+import ViewTypeFileSmall from "@figshare/fcl/icons/viewType/file/small";
+import ViewTypeFileLarge from "@figshare/fcl/icons/viewType/file/large";
 
 <Story name="ViewType">
   <ViewTypeThumbnailSmall className={styles.icon} />
@@ -435,8 +435,8 @@ import ViewTypeFileLarge from "@figshare/fcl/icons/viewType/file/large";
 ---
 ## Zoom
 
-import ZoomIn from "@figshare/ui/icons/zoom/in";
-import ZoomOut from "@figshare/ui/icons/zoom/out";
+import ZoomIn from "@figshare/fcl/icons/zoom/in";
+import ZoomOut from "@figshare/fcl/icons/zoom/out";
 
 <Story name="Zoom">
   <ZoomIn className={styles.icon} />
@@ -451,7 +451,7 @@ import ZoomOut from "@figshare/fcl/icons/zoom/out";
 ---
 ## Download
 
-import Download from "@figshare/ui/icons/download";
+import Download from "@figshare/fcl/icons/download";
 
 <Story name="Download">
   <Download className={styles.icon} />
@@ -464,7 +464,7 @@ import Download from "@figshare/fcl/icons/download";
 ---
 ## Upload
 
-import Upload from "@figshare/ui/icons/upload";
+import Upload from "@figshare/fcl/icons/upload";
 
 <Story name="Upload">
   <Upload className={styles.icon} />
@@ -477,8 +477,8 @@ import Upload from "@figshare/fcl/icons/upload";
 ---
 ## Info
 
-import InfoSmall from "@figshare/ui/icons/info/small";
-import InfoMedium from "@figshare/ui/icons/info/medium";
+import InfoSmall from "@figshare/fcl/icons/info/small";
+import InfoMedium from "@figshare/fcl/icons/info/medium";
 
 <Story name="Info">
   <InfoSmall className={styles.icon} />
@@ -493,8 +493,8 @@ import InfoMedium from "@figshare/fcl/icons/info/medium";
 ---
 ## Warning
 
-import WarningSmall from "@figshare/ui/icons/warning/small";
-import WarningMedium from "@figshare/ui/icons/warning/medium";
+import WarningSmall from "@figshare/fcl/icons/warning/small";
+import WarningMedium from "@figshare/fcl/icons/warning/medium";
 
 <Story name="Warning">
   <WarningSmall className={styles.icon} />
@@ -509,10 +509,10 @@ import WarningMedium from "@figshare/fcl/icons/warning/medium";
 ---
 ## Eye
 
-import EyeVisibleSmall from "@figshare/ui/icons/eye/visible/small";
-import EyeVisibleMedium from "@figshare/ui/icons/eye/visible/medium";
-import EyeInvisibleSmall from "@figshare/ui/icons/eye/invisible/small";
-import EyeInvisibleMedium from "@figshare/ui/icons/eye/invisible/medium";
+import EyeVisibleSmall from "@figshare/fcl/icons/eye/visible/small";
+import EyeVisibleMedium from "@figshare/fcl/icons/eye/visible/medium";
+import EyeInvisibleSmall from "@figshare/fcl/icons/eye/invisible/small";
+import EyeInvisibleMedium from "@figshare/fcl/icons/eye/invisible/medium";
 
 <Story name="Eye">
   <EyeVisibleSmall className={styles.icon} />
@@ -531,10 +531,10 @@ import EyeInvisibleMedium from "@figshare/fcl/icons/eye/invisible/medium";
 ---
 ## Filters
 
-import FiltersShowSmall from "@figshare/ui/icons/filters/show/small";
-import FiltersShowLarge from "@figshare/ui/icons/filters/show/large";
-import FiltersHideSmall from "@figshare/ui/icons/filters/hide/small";
-import FiltersHideLarge from "@figshare/ui/icons/filters/hide/large";
+import FiltersShowSmall from "@figshare/fcl/icons/filters/show/small";
+import FiltersShowLarge from "@figshare/fcl/icons/filters/show/large";
+import FiltersHideSmall from "@figshare/fcl/icons/filters/hide/small";
+import FiltersHideLarge from "@figshare/fcl/icons/filters/hide/large";
 
 <Story name="Filters">
   <FiltersShowSmall className={styles.icon} />
@@ -553,8 +553,8 @@ import FiltersHideLarge from "@figshare/fcl/icons/filters/hide/large";
 ---
 ## Email
 
-import EmailSmall from "@figshare/ui/icons/email/small";
-import EmailLarge from "@figshare/ui/icons/email/large";
+import EmailSmall from "@figshare/fcl/icons/email/small";
+import EmailLarge from "@figshare/fcl/icons/email/large";
 
 <Story name="Email">
   <EmailSmall className={styles.icon} />
@@ -569,8 +569,8 @@ import EmailLarge from "@figshare/fcl/icons/email/large";
 ---
 ## Menu
 
-import MenuSmall from "@figshare/ui/icons/menu/small";
-import MenuLarge from "@figshare/ui/icons/menu/large";
+import MenuSmall from "@figshare/fcl/icons/menu/small";
+import MenuLarge from "@figshare/fcl/icons/menu/large";
 
 <Story name="Menu">
   <MenuSmall className={styles.icon} />
@@ -585,8 +585,8 @@ import MenuLarge from "@figshare/fcl/icons/menu/large";
 ---
 ## List
 
-import ListSmall from "@figshare/ui/icons/list/small";
-import ListLarge from "@figshare/ui/icons/list/large";
+import ListSmall from "@figshare/fcl/icons/list/small";
+import ListLarge from "@figshare/fcl/icons/list/large";
 
 <Story name="List">
   <ListSmall className={styles.icon} />
@@ -601,9 +601,9 @@ import ListLarge from "@figshare/fcl/icons/list/large";
 ---
 ## User
 
-import UserSmall from "@figshare/ui/icons/user/small";
-import UserMedium from "@figshare/ui/icons/user/medium";
-import UserLarge from "@figshare/ui/icons/user/large";
+import UserSmall from "@figshare/fcl/icons/user/small";
+import UserMedium from "@figshare/fcl/icons/user/medium";
+import UserLarge from "@figshare/fcl/icons/user/large";
 
 <Story name="User">
   <UserSmall className={styles.icon} />
@@ -620,9 +620,9 @@ import UserLarge from "@figshare/fcl/icons/user/large";
 ---
 ## CheckBox
 
-import CheckBoxChecked from "@figshare/ui/icons/checkBox/checked";
-import CheckBoxUnchecked from "@figshare/ui/icons/checkBox/unchecked";
-import CheckBoxMixed from "@figshare/ui/icons/checkBox/mixed";
+import CheckBoxChecked from "@figshare/fcl/icons/checkBox/checked";
+import CheckBoxUnchecked from "@figshare/fcl/icons/checkBox/unchecked";
+import CheckBoxMixed from "@figshare/fcl/icons/checkBox/mixed";
 
 <Story name="CheckBox">
   <CheckBoxChecked className={styles.icon} />
@@ -639,8 +639,8 @@ import CheckBoxMixed from "@figshare/fcl/icons/checkBox/mixed";
 ---
 ## Radio
 
-import RadioChecked from "@figshare/ui/icons/radio/checked";
-import RadioUnchecked from "@figshare/ui/icons/radio/unchecked";
+import RadioChecked from "@figshare/fcl/icons/radio/checked";
+import RadioUnchecked from "@figshare/fcl/icons/radio/unchecked";
 
 <Story name="Radio">
   <RadioChecked className={styles.icon} />
@@ -655,7 +655,7 @@ import RadioUnchecked from "@figshare/fcl/icons/radio/unchecked";
 ---
 ## MoreOptions
 
-import MoreOptions from "@figshare/ui/icons/moreOptions";
+import MoreOptions from "@figshare/fcl/icons/moreOptions";
 
 <Story name="MoreOptions">
   <MoreOptions className={styles.icon} />
@@ -668,10 +668,10 @@ import MoreOptions from "@figshare/fcl/icons/moreOptions";
 ---
 ## Earth
 
-import EarthPublicSmall from "@figshare/ui/icons/earth/public/small";
-import EarthPublicMedium from "@figshare/ui/icons/earth/public/medium";
-import EarthPrivateSmall from "@figshare/ui/icons/earth/private/small";
-import EarthPrivateMedium from "@figshare/ui/icons/earth/private/medium";
+import EarthPublicSmall from "@figshare/fcl/icons/earth/public/small";
+import EarthPublicMedium from "@figshare/fcl/icons/earth/public/medium";
+import EarthPrivateSmall from "@figshare/fcl/icons/earth/private/small";
+import EarthPrivateMedium from "@figshare/fcl/icons/earth/private/medium";
 
 <Story name="Earth">
   <EarthPublicSmall className={styles.icon} />
@@ -690,9 +690,9 @@ import EarthPrivateMedium from "@figshare/fcl/icons/earth/private/medium";
 ---
 ## Settings
 
-import SettingsSmall from "@figshare/ui/icons/settings/small";
-import SettingsMedium from "@figshare/ui/icons/settings/medium";
-import SettingsLarge from "@figshare/ui/icons/settings/large";
+import SettingsSmall from "@figshare/fcl/icons/settings/small";
+import SettingsMedium from "@figshare/fcl/icons/settings/medium";
+import SettingsLarge from "@figshare/fcl/icons/settings/large";
 
 <Story name="Settings">
   <SettingsSmall className={styles.icon} />
@@ -709,9 +709,9 @@ import SettingsLarge from "@figshare/fcl/icons/settings/large";
 ---
 ## Delete
 
-import DeleteSmall from "@figshare/ui/icons/delete/small";
-import DeleteMedium from "@figshare/ui/icons/delete/medium";
-import DeleteLarge from "@figshare/ui/icons/delete/large";
+import DeleteSmall from "@figshare/fcl/icons/delete/small";
+import DeleteMedium from "@figshare/fcl/icons/delete/medium";
+import DeleteLarge from "@figshare/fcl/icons/delete/large";
 
 <Story name="Delete">
   <DeleteSmall className={styles.icon} />
@@ -728,7 +728,7 @@ import DeleteLarge from "@figshare/fcl/icons/delete/large";
 ---
 ## Timer
 
-import Timer from "@figshare/ui/icons/timer";
+import Timer from "@figshare/fcl/icons/timer";
 
 <Story name="Timer">
   <Timer className={styles.icon} />
@@ -741,8 +741,8 @@ import Timer from "@figshare/fcl/icons/timer";
 ---
 ## GoToLink
 
-import GoToLinkSmall from "@figshare/ui/icons/goToLink/small";
-import GoToLinkLarge from "@figshare/ui/icons/goToLink/large";
+import GoToLinkSmall from "@figshare/fcl/icons/goToLink/small";
+import GoToLinkLarge from "@figshare/fcl/icons/goToLink/large";
 
 <Story name="GoToLink">
   <GoToLinkSmall className={styles.icon} />
@@ -757,8 +757,8 @@ import GoToLinkLarge from "@figshare/fcl/icons/goToLink/large";
 ---
 ## Link
 
-import LinkLinked from "@figshare/ui/icons/link/linked";
-import LinkUnlinked from "@figshare/ui/icons/link/unlinked";
+import LinkLinked from "@figshare/fcl/icons/link/linked";
+import LinkUnlinked from "@figshare/fcl/icons/link/unlinked";
 
 <Story name="Link">
   <LinkLinked className={styles.icon} />
@@ -773,8 +773,8 @@ import LinkUnlinked from "@figshare/fcl/icons/link/unlinked";
 ---
 ## Chain
 
-import ChainLinked from "@figshare/ui/icons/chain/linked";
-import ChainUnlinked from "@figshare/ui/icons/chain/unlinked";
+import ChainLinked from "@figshare/fcl/icons/chain/linked";
+import ChainUnlinked from "@figshare/fcl/icons/chain/unlinked";
 
 <Story name="Chain">
   <ChainLinked className={styles.icon} />
@@ -789,8 +789,8 @@ import ChainUnlinked from "@figshare/fcl/icons/chain/unlinked";
 ---
 ## Notification
 
-import NotificationInactive from "@figshare/ui/icons/notification/inactive";
-import NotificationActive from "@figshare/ui/icons/notification/active";
+import NotificationInactive from "@figshare/fcl/icons/notification/inactive";
+import NotificationActive from "@figshare/fcl/icons/notification/active";
 
 <Story name="Notification">
   <NotificationInactive className={styles.icon} />
@@ -805,9 +805,9 @@ import NotificationActive from "@figshare/fcl/icons/notification/active";
 ---
 ## Edit
 
-import EditSmall from "@figshare/ui/icons/edit/small";
-import EditMedium from "@figshare/ui/icons/edit/medium";
-import EditLarge from "@figshare/ui/icons/edit/large";
+import EditSmall from "@figshare/fcl/icons/edit/small";
+import EditMedium from "@figshare/fcl/icons/edit/medium";
+import EditLarge from "@figshare/fcl/icons/edit/large";
 
 <Story name="Edit">
   <EditSmall className={styles.icon} />
@@ -824,7 +824,7 @@ import EditLarge from "@figshare/fcl/icons/edit/large";
 ---
 ## FitToScreen
 
-import FitToScreen from "@figshare/ui/icons/fitToScreen";
+import FitToScreen from "@figshare/fcl/icons/fitToScreen";
 
 <Story name="FitToScreen">
   <FitToScreen className={styles.icon} />
@@ -837,7 +837,7 @@ import FitToScreen from "@figshare/fcl/icons/fitToScreen";
 ---
 ## DragAndDrop
 
-import DragAndDrop from "@figshare/ui/icons/dragAndDrop";
+import DragAndDrop from "@figshare/fcl/icons/dragAndDrop";
 
 <Story name="DragAndDrop">
   <DragAndDrop className={styles.icon} />
@@ -850,7 +850,7 @@ import DragAndDrop from "@figshare/fcl/icons/dragAndDrop";
 ---
 ## Papers
 
-import Papers from "@figshare/ui/icons/papers";
+import Papers from "@figshare/fcl/icons/papers";
 
 <Story name="Papers">
   <Papers className={styles.icon} />
@@ -863,7 +863,7 @@ import Papers from "@figshare/fcl/icons/papers";
 ---
 ## Calendar
 
-import Calendar from "@figshare/ui/icons/calendar";
+import Calendar from "@figshare/fcl/icons/calendar";
 
 <Story name="Calendar">
   <Calendar className={styles.icon} />
@@ -876,8 +876,8 @@ import Calendar from "@figshare/fcl/icons/calendar";
 ---
 ## Fullscreen
 
-import FullscreenEnter from "@figshare/ui/icons/fullscreen/enter";
-import FullscreenExit from "@figshare/ui/icons/fullscreen/exit";
+import FullscreenEnter from "@figshare/fcl/icons/fullscreen/enter";
+import FullscreenExit from "@figshare/fcl/icons/fullscreen/exit";
 
 <Story name="Fullscreen">
   <FullscreenEnter className={styles.icon} />
@@ -892,8 +892,8 @@ import FullscreenExit from "@figshare/fcl/icons/fullscreen/exit";
 ---
 ## Undo
 
-import UndoSmall from "@figshare/ui/icons/undo/small";
-import UndoMedium from "@figshare/ui/icons/undo/medium";
+import UndoSmall from "@figshare/fcl/icons/undo/small";
+import UndoMedium from "@figshare/fcl/icons/undo/medium";
 
 <Story name="Undo">
   <UndoSmall className={styles.icon} />
@@ -908,8 +908,8 @@ import UndoMedium from "@figshare/fcl/icons/undo/medium";
 ---
 ## Retry
 
-import RetrySmall from "@figshare/ui/icons/retry/small";
-import RetryMedium from "@figshare/ui/icons/retry/medium";
+import RetrySmall from "@figshare/fcl/icons/retry/small";
+import RetryMedium from "@figshare/fcl/icons/retry/medium";
 
 <Story name="Retry">
   <RetrySmall className={styles.icon} />
@@ -924,8 +924,8 @@ import RetryMedium from "@figshare/fcl/icons/retry/medium";
 ---
 ## Replay
 
-import ReplaySmall from "@figshare/ui/icons/replay/small";
-import ReplayMedium from "@figshare/ui/icons/replay/medium";
+import ReplaySmall from "@figshare/fcl/icons/replay/small";
+import ReplayMedium from "@figshare/fcl/icons/replay/medium";
 
 <Story name="Replay">
   <ReplaySmall className={styles.icon} />
@@ -940,10 +940,10 @@ import ReplayMedium from "@figshare/fcl/icons/replay/medium";
 ---
 ## Volume
 
-import VolumeMute from "@figshare/ui/icons/volume/mute";
-import VolumeLow from "@figshare/ui/icons/volume/low";
-import VolumeMedium from "@figshare/ui/icons/volume/medium";
-import VolumeHigh from "@figshare/ui/icons/volume/high";
+import VolumeMute from "@figshare/fcl/icons/volume/mute";
+import VolumeLow from "@figshare/fcl/icons/volume/low";
+import VolumeMedium from "@figshare/fcl/icons/volume/medium";
+import VolumeHigh from "@figshare/fcl/icons/volume/high";
 
 <Story name="Volume">
   <VolumeMute className={styles.icon} />
@@ -962,8 +962,8 @@ import VolumeHigh from "@figshare/fcl/icons/volume/high";
 ---
 ## Play
 
-import PlaySmall from "@figshare/ui/icons/play/small";
-import PlayLarge from "@figshare/ui/icons/play/large";
+import PlaySmall from "@figshare/fcl/icons/play/small";
+import PlayLarge from "@figshare/fcl/icons/play/large";
 
 <Story name="Play">
   <PlaySmall className={styles.icon} />
@@ -978,8 +978,8 @@ import PlayLarge from "@figshare/fcl/icons/play/large";
 ---
 ## Pause
 
-import PauseSmall from "@figshare/ui/icons/pause/small";
-import PauseLarge from "@figshare/ui/icons/pause/large";
+import PauseSmall from "@figshare/fcl/icons/pause/small";
+import PauseLarge from "@figshare/fcl/icons/pause/large";
 
 <Story name="Pause">
   <PauseSmall className={styles.icon} />
@@ -994,8 +994,8 @@ import PauseLarge from "@figshare/fcl/icons/pause/large";
 ---
 ## Jump
 
-import JumpBack from "@figshare/ui/icons/jump/back";
-import JumpForward from "@figshare/ui/icons/jump/forward";
+import JumpBack from "@figshare/fcl/icons/jump/back";
+import JumpForward from "@figshare/fcl/icons/jump/forward";
 
 <Story name="Jump">
   <JumpBack className={styles.icon} />
@@ -1010,24 +1010,24 @@ import JumpForward from "@figshare/fcl/icons/jump/forward";
 ---
 ## Editor
 
-import Bold from "@figshare/ui/icons/editor/bold";
-import BulletList from "@figshare/ui/icons/editor/bulletList";
-import ClearFormatting from "@figshare/ui/icons/editor/clearFormatting";
-import HeadingTwo from "@figshare/ui/icons/editor/h2";
-import HeadingThree from "@figshare/ui/icons/editor/h3";
-import HeadingFour from "@figshare/ui/icons/editor/h4";
+import Bold from "@figshare/fcl/icons/editor/bold";
+import BulletList from "@figshare/fcl/icons/editor/bulletList";
+import ClearFormatting from "@figshare/fcl/icons/editor/clearFormatting";
+import HeadingTwo from "@figshare/fcl/icons/editor/h2";
+import HeadingThree from "@figshare/fcl/icons/editor/h3";
+import HeadingFour from "@figshare/fcl/icons/editor/h4";
 
-import Italic from "@figshare/ui/icons/editor/italic";
-import Link from "@figshare/ui/icons/editor/link";
-import NumberedList from "@figshare/ui/icons/editor/numberedList";
-import Paragraph from "@figshare/ui/icons/editor/paragraph";
-import PasteAsPlainText from "@figshare/ui/icons/editor/paste";
-import Redo from "@figshare/ui/icons/editor/redo";
-import Strikethrough from "@figshare/ui/icons/editor/strikethrough";
-import Subscript from "@figshare/ui/icons/editor/subscript";
-import Superscript from "@figshare/ui/icons/editor/superscript";
-import Underline from "@figshare/ui/icons/editor/underline";
-import Undo from "@figshare/ui/icons/editor/undo";
+import Italic from "@figshare/fcl/icons/editor/italic";
+import Link from "@figshare/fcl/icons/editor/link";
+import NumberedList from "@figshare/fcl/icons/editor/numberedList";
+import Paragraph from "@figshare/fcl/icons/editor/paragraph";
+import PasteAsPlainText from "@figshare/fcl/icons/editor/paste";
+import Redo from "@figshare/fcl/icons/editor/redo";
+import Strikethrough from "@figshare/fcl/icons/editor/strikethrough";
+import Subscript from "@figshare/fcl/icons/editor/subscript";
+import Superscript from "@figshare/fcl/icons/editor/superscript";
+import Underline from "@figshare/fcl/icons/editor/underline";
+import Undo from "@figshare/fcl/icons/editor/undo";
 
 <Story name="Editor">
   <Bold className={styles.icon} />
@@ -1073,7 +1073,7 @@ import Undo from "@figshare/fcl/icons/editor/undo";
 ---
 ## Duplicate
 
-import Duplicate from "@figshare/ui/icons/duplicate";
+import Duplicate from "@figshare/fcl/icons/duplicate";
 
 <Story name="Duplicate">
   <Duplicate className={styles.icon} />
@@ -1086,8 +1086,8 @@ import Duplicate from "@figshare/fcl/icons/duplicate";
 ---
 ## FontSize
 
-import FontSizeSmaller from "@figshare/ui/icons/fontSize/smaller";
-import FontSizeLarger from "@figshare/ui/icons/fontSize/larger";
+import FontSizeSmaller from "@figshare/fcl/icons/fontSize/smaller";
+import FontSizeLarger from "@figshare/fcl/icons/fontSize/larger";
 
 <Story name="FontSize">
   <FontSizeSmaller className={styles.icon} />
@@ -1102,8 +1102,8 @@ import FontSizeLarger from "@figshare/fcl/icons/fontSize/larger";
 ---
 ## Share
 
-import ShareSmall from "@figshare/ui/icons/share/small";
-import ShareLarge from "@figshare/ui/icons/share/large";
+import ShareSmall from "@figshare/fcl/icons/share/small";
+import ShareLarge from "@figshare/fcl/icons/share/large";
 
 <Story name="Share">
   <ShareSmall className={styles.icon} />
@@ -1118,7 +1118,7 @@ import ShareLarge from "@figshare/fcl/icons/share/large";
 ---
 ## FTP
 
-import FTP from "@figshare/ui/icons/ftp";
+import FTP from "@figshare/fcl/icons/ftp";
 
 <Story name="FTP">
   <FTP className={styles.icon} />
@@ -1131,7 +1131,7 @@ import FTP from "@figshare/fcl/icons/ftp";
 ---
 ## Histogram
 
-import Histogram from "@figshare/ui/icons/histogram";
+import Histogram from "@figshare/fcl/icons/histogram";
 
 <Story name="Histogram">
   <Histogram className={styles.icon} />
@@ -1144,7 +1144,7 @@ import Histogram from "@figshare/fcl/icons/histogram";
 ---
 ## Statistics
 
-import Statistics from "@figshare/ui/icons/statistics";
+import Statistics from "@figshare/fcl/icons/statistics";
 
 <Story name="Statistics">
   <Statistics className={styles.icon} />
@@ -1157,10 +1157,10 @@ import Statistics from "@figshare/fcl/icons/statistics";
 ---
 ## ExpandTo / CollapseTo
 
-import ExpandToLeft from "@figshare/ui/icons/expandTo/left";
-import CollapseToRight from "@figshare/ui/icons/collapseTo/right";
-import ExpandToRight from "@figshare/ui/icons/expandTo/right";
-import CollapseToLeft from "@figshare/ui/icons/collapseTo/left";
+import ExpandToLeft from "@figshare/fcl/icons/expandTo/left";
+import CollapseToRight from "@figshare/fcl/icons/collapseTo/right";
+import ExpandToRight from "@figshare/fcl/icons/expandTo/right";
+import CollapseToLeft from "@figshare/fcl/icons/collapseTo/left";
 
 <Story name="ExpandTo / CollapseTo">
   <ExpandToLeft className={styles.icon} />
@@ -1179,7 +1179,7 @@ import CollapseToLeft from "@figshare/fcl/icons/collapseTo/left";
 ---
 ## LocationPin
 
-import LocationPin from "@figshare/ui/icons/locationPin";
+import LocationPin from "@figshare/fcl/icons/locationPin";
 
 <Story name="LocationPin">
   <LocationPin className={styles.icon} />
@@ -1192,9 +1192,9 @@ import LocationPin from "@figshare/fcl/icons/locationPin";
 ---
 ## Project
 
-import ProjectSmall from "@figshare/ui/icons/project/small";
-import ProjectMedium from "@figshare/ui/icons/project/medium";
-import ProjectLarge from "@figshare/ui/icons/project/large";
+import ProjectSmall from "@figshare/fcl/icons/project/small";
+import ProjectMedium from "@figshare/fcl/icons/project/medium";
+import ProjectLarge from "@figshare/fcl/icons/project/large";
 
 <Story name="Project">
   <ProjectSmall className={styles.icon} />
@@ -1211,9 +1211,9 @@ import ProjectLarge from "@figshare/fcl/icons/project/large";
 ---
 ## Collection
 
-import CollectionSmall from "@figshare/ui/icons/collection/small";
-import CollectionMedium from "@figshare/ui/icons/collection/medium";
-import CollectionLarge from "@figshare/ui/icons/collection/large";
+import CollectionSmall from "@figshare/fcl/icons/collection/small";
+import CollectionMedium from "@figshare/fcl/icons/collection/medium";
+import CollectionLarge from "@figshare/fcl/icons/collection/large";
 
 <Story name="Collection">
   <CollectionSmall className={styles.icon} />
@@ -1230,9 +1230,9 @@ import CollectionLarge from "@figshare/fcl/icons/collection/large";
 ---
 ## Users
 
-import UsersSmall from "@figshare/ui/icons/users/small";
-import UsersMedium from "@figshare/ui/icons/users/medium";
-import UsersLarge from "@figshare/ui/icons/users/large";
+import UsersSmall from "@figshare/fcl/icons/users/small";
+import UsersMedium from "@figshare/fcl/icons/users/medium";
+import UsersLarge from "@figshare/fcl/icons/users/large";
 
 <Story name="Users">
   <UsersSmall className={styles.icon} />
@@ -1249,9 +1249,9 @@ import UsersLarge from "@figshare/fcl/icons/users/large";
 ---
 ## Institution
 
-import InstitutionSmall from "@figshare/ui/icons/institution/small";
-import InstitutionMedium from "@figshare/ui/icons/institution/medium";
-import InstitutionLarge from "@figshare/ui/icons/institution/large";
+import InstitutionSmall from "@figshare/fcl/icons/institution/small";
+import InstitutionMedium from "@figshare/fcl/icons/institution/medium";
+import InstitutionLarge from "@figshare/fcl/icons/institution/large";
 
 <Story name="Institution">
   <InstitutionSmall className={styles.icon} />
@@ -1268,9 +1268,9 @@ import InstitutionLarge from "@figshare/fcl/icons/institution/large";
 ---
 ## Note
 
-import NoteSmall from "@figshare/ui/icons/note/small";
-import NoteMedium from "@figshare/ui/icons/note/medium";
-import NoteLarge from "@figshare/ui/icons/note/large";
+import NoteSmall from "@figshare/fcl/icons/note/small";
+import NoteMedium from "@figshare/fcl/icons/note/medium";
+import NoteLarge from "@figshare/fcl/icons/note/large";
 
 <Story name="Note">
   <NoteSmall className={styles.icon} />
@@ -1287,9 +1287,9 @@ import NoteLarge from "@figshare/fcl/icons/note/large";
 ---
 ## Quote
 
-import QuoteSmall from "@figshare/ui/icons/quote/small";
-import QuoteMedium from "@figshare/ui/icons/quote/medium";
-import QuoteLarge from "@figshare/ui/icons/quote/large";
+import QuoteSmall from "@figshare/fcl/icons/quote/small";
+import QuoteMedium from "@figshare/fcl/icons/quote/medium";
+import QuoteLarge from "@figshare/fcl/icons/quote/large";
 
 <Story name="Quote">
   <QuoteSmall className={styles.icon} />
@@ -1308,9 +1308,9 @@ import QuoteLarge from "@figshare/fcl/icons/quote/large";
 ---
 ## Document
 
-import DocumentSmall from "@figshare/ui/icons/document/small";
-import DocumentMedium from "@figshare/ui/icons/document/medium";
-import DocumentLarge from "@figshare/ui/icons/document/large";
+import DocumentSmall from "@figshare/fcl/icons/document/small";
+import DocumentMedium from "@figshare/fcl/icons/document/medium";
+import DocumentLarge from "@figshare/fcl/icons/document/large";
 
 <Story name="Document">
   <DocumentSmall className={styles.icon} />
@@ -1329,9 +1329,9 @@ import DocumentLarge from "@figshare/fcl/icons/document/large";
 ---
 ## XML
 
-import XMLSmall from "@figshare/ui/icons/xml/small";
-import XMLMedium from "@figshare/ui/icons/xml/medium";
-import XMLLarge from "@figshare/ui/icons/xml/large";
+import XMLSmall from "@figshare/fcl/icons/xml/small";
+import XMLMedium from "@figshare/fcl/icons/xml/medium";
+import XMLLarge from "@figshare/fcl/icons/xml/large";
 
 <Story name="XML">
   <XMLSmall className={styles.icon} />
@@ -1350,9 +1350,9 @@ import XMLLarge from "@figshare/fcl/icons/xml/large";
 ---
 ## SplitDocument
 
-import SplitDocumentSmall from "@figshare/ui/icons/splitDocument/small";
-import SplitDocumentMedium from "@figshare/ui/icons/splitDocument/medium";
-import SplitDocumentLarge from "@figshare/ui/icons/splitDocument/large";
+import SplitDocumentSmall from "@figshare/fcl/icons/splitDocument/small";
+import SplitDocumentMedium from "@figshare/fcl/icons/splitDocument/medium";
+import SplitDocumentLarge from "@figshare/fcl/icons/splitDocument/large";
 
 <Story name="SplitDocument">
   <SplitDocumentSmall className={styles.icon} />
@@ -1371,9 +1371,9 @@ import SplitDocumentLarge from "@figshare/fcl/icons/splitDocument/large";
 ---
 ## File
 
-import FileSmall from "@figshare/ui/icons/file/small";
-import FileMedium from "@figshare/ui/icons/file/medium";
-import FileLarge from "@figshare/ui/icons/file/large";
+import FileSmall from "@figshare/fcl/icons/file/small";
+import FileMedium from "@figshare/fcl/icons/file/medium";
+import FileLarge from "@figshare/fcl/icons/file/large";
 
 <Story name="File">
   <FileSmall className={styles.icon} />

--- a/stories/icons/itemType/index.stories.mdx
+++ b/stories/icons/itemType/index.stories.mdx
@@ -19,7 +19,7 @@ An icon set used to visually represent article item types.
 
 ## Preprint
 
-import ItemTypePreprint from "@figshare/ui/icons/itemType/preprint";
+import ItemTypePreprint from "@figshare/fcl/icons/itemType/preprint";
 
 <Story name="Preprint">
   <ItemTypePreprint className={styles.icon} />
@@ -33,7 +33,7 @@ import ItemTypePreprint from "@figshare/fcl/icons/itemType/preprint";
 ---
 ## Book
 
-import ItemTypeBook from "@figshare/ui/icons/itemType/book";
+import ItemTypeBook from "@figshare/fcl/icons/itemType/book";
 
 <Story name="Book">
   <ItemTypeBook className={styles.icon} />
@@ -48,7 +48,7 @@ import ItemTypeBook from "@figshare/fcl/icons/itemType/book";
 ---
 ## Software
 
-import ItemTypeSoftware from "@figshare/ui/icons/itemType/software";
+import ItemTypeSoftware from "@figshare/fcl/icons/itemType/software";
 
 <Story name="Software">
   <ItemTypeSoftware className={styles.icon} />
@@ -63,7 +63,7 @@ import ItemTypeSoftware from "@figshare/fcl/icons/itemType/software";
 ---
 ## Paper
 
-import ItemTypePaper from "@figshare/ui/icons/itemType/paper";
+import ItemTypePaper from "@figshare/fcl/icons/itemType/paper";
 
 <Story name="Paper">
   <ItemTypePaper className={styles.icon} />
@@ -78,7 +78,7 @@ import ItemTypePaper from "@figshare/fcl/icons/itemType/paper";
 ---
 ## Metadata
 
-import ItemTypeMetadata from "@figshare/ui/icons/itemType/metadata";
+import ItemTypeMetadata from "@figshare/fcl/icons/itemType/metadata";
 
 <Story name="Metadata">
   <ItemTypeMetadata className={styles.icon} />
@@ -93,7 +93,7 @@ import ItemTypeMetadata from "@figshare/fcl/icons/itemType/metadata";
 ---
 ## Thesis
 
-import ItemTypeThesis from "@figshare/ui/icons/itemType/thesis";
+import ItemTypeThesis from "@figshare/fcl/icons/itemType/thesis";
 
 <Story name="Thesis">
   <ItemTypeThesis className={styles.icon} />
@@ -107,7 +107,7 @@ import ItemTypeThesis from "@figshare/fcl/icons/itemType/thesis";
 ---
 ## Poster
 
-import ItemTypePoster from "@figshare/ui/icons/itemType/poster";
+import ItemTypePoster from "@figshare/fcl/icons/itemType/poster";
 
 <Story name="Poster">
   <ItemTypePoster className={styles.icon} />
@@ -122,7 +122,7 @@ import ItemTypePoster from "@figshare/fcl/icons/itemType/poster";
 ---
 ## Dataset
 
-import ItemTypeDataset from "@figshare/ui/icons/itemType/dataset";
+import ItemTypeDataset from "@figshare/fcl/icons/itemType/dataset";
 
 <Story name="Dataset">
   <ItemTypeDataset className={styles.icon} />
@@ -137,7 +137,7 @@ import ItemTypeDataset from "@figshare/fcl/icons/itemType/dataset";
 ---
 ## Media
 
-import ItemTypeMedia from "@figshare/ui/icons/itemType/media";
+import ItemTypeMedia from "@figshare/fcl/icons/itemType/media";
 
 <Story name="Media">
   <ItemTypeMedia className={styles.icon} />
@@ -152,7 +152,7 @@ import ItemTypeMedia from "@figshare/fcl/icons/itemType/media";
 ---
 ## Figure
 
-import ItemTypeFigure from "@figshare/ui/icons/itemType/figure";
+import ItemTypeFigure from "@figshare/fcl/icons/itemType/figure";
 
 <Story name="Figure">
   <ItemTypeFigure className={styles.icon} />
@@ -167,7 +167,7 @@ import ItemTypeFigure from "@figshare/fcl/icons/itemType/figure";
 ---
 ## Presentation
 
-import ItemTypePresentation from "@figshare/ui/icons/itemType/presentation";
+import ItemTypePresentation from "@figshare/fcl/icons/itemType/presentation";
 
 <Story name="Presentation">
   <ItemTypePresentation className={styles.icon} />
@@ -182,7 +182,7 @@ import ItemTypePresentation from "@figshare/fcl/icons/itemType/presentation";
 ---
 ## OnlineResource
 
-import ItemTypeOnlineResource from "@figshare/ui/icons/itemType/onlineResource";
+import ItemTypeOnlineResource from "@figshare/fcl/icons/itemType/onlineResource";
 
 <Story name="OnlineResource">
   <ItemTypeOnlineResource className={styles.icon} />
@@ -197,7 +197,7 @@ import ItemTypeOnlineResource from "@figshare/fcl/icons/itemType/onlineResource"
 ---
 ## Workflow
 
-import ItemTypeWorkflow from "@figshare/ui/icons/itemType/workflow";
+import ItemTypeWorkflow from "@figshare/fcl/icons/itemType/workflow";
 
 <Story name="Workflow">
   <ItemTypeWorkflow className={styles.icon} />
@@ -212,7 +212,7 @@ import ItemTypeWorkflow from "@figshare/fcl/icons/itemType/workflow";
 ---
 ## Performance
 
-import ItemTypePerformance from "@figshare/ui/icons/itemType/performance";
+import ItemTypePerformance from "@figshare/fcl/icons/itemType/performance";
 
 <Story name="Performance">
   <ItemTypePerformance className={styles.icon} />
@@ -227,7 +227,7 @@ import ItemTypePerformance from "@figshare/fcl/icons/itemType/performance";
 ---
 ## Collection
 
-import ItemTypeCollection from "@figshare/ui/icons/itemType/collection";
+import ItemTypeCollection from "@figshare/fcl/icons/itemType/collection";
 
 <Story name="Collection">
   <ItemTypeCollection className={styles.icon} />
@@ -242,7 +242,7 @@ import ItemTypeCollection from "@figshare/fcl/icons/itemType/collection";
 ---
 ## Project
 
-import ItemTypeProject from "@figshare/ui/icons/itemType/project";
+import ItemTypeProject from "@figshare/fcl/icons/itemType/project";
 
 <Story name="Project">
   <ItemTypeProject className={styles.icon} />

--- a/stories/icons/presentation/index.stories.mdx
+++ b/stories/icons/presentation/index.stories.mdx
@@ -17,19 +17,19 @@ import styles from "./index.stories.css";
 
 An icon set for "presentation" related items. Icons for items ranging from projects, to individual publications, or simple quotations. 
 
-import Quote from "@figshare/ui/icons/presentation/quote";
-import Project from "@figshare/ui/icons/presentation/project";
-import Collection from "@figshare/ui/icons/presentation/collection";
-import Exclamation from "@figshare/ui/icons/presentation/exclamation";
-import CheckMark from "@figshare/ui/icons/presentation/checkMark";
-import Note from "@figshare/ui/icons/presentation/note";
-import FTP from "@figshare/ui/icons/presentation/ftp";
-import EnvelopeSuccess from "@figshare/ui/icons/presentation/envelopeSuccess";
-import EnvelopeError from "@figshare/ui/icons/presentation/envelopeError";
-import EmbedCode from "@figshare/ui/icons/presentation/embedCode";
-import EmbedTitle from "@figshare/ui/icons/presentation/embedTitle";
-import Ribbon from "@figshare/ui/icons/presentation/ribbon";
-import Publications from "@figshare/ui/icons/presentation/publications";
+import Quote from "@figshare/fcl/icons/presentation/quote";
+import Project from "@figshare/fcl/icons/presentation/project";
+import Collection from "@figshare/fcl/icons/presentation/collection";
+import Exclamation from "@figshare/fcl/icons/presentation/exclamation";
+import CheckMark from "@figshare/fcl/icons/presentation/checkMark";
+import Note from "@figshare/fcl/icons/presentation/note";
+import FTP from "@figshare/fcl/icons/presentation/ftp";
+import EnvelopeSuccess from "@figshare/fcl/icons/presentation/envelopeSuccess";
+import EnvelopeError from "@figshare/fcl/icons/presentation/envelopeError";
+import EmbedCode from "@figshare/fcl/icons/presentation/embedCode";
+import EmbedTitle from "@figshare/fcl/icons/presentation/embedTitle";
+import Ribbon from "@figshare/fcl/icons/presentation/ribbon";
+import Publications from "@figshare/fcl/icons/presentation/publications";
 
 <Story 
   name="Presentation"
@@ -54,19 +54,19 @@ import Publications from "@figshare/ui/icons/presentation/publications";
 </Story>
 
 ```jsx
-import Quote from "@figshare/ui/icons/presentation/quote";
-import Project from "@figshare/ui/icons/presentation/project";
-import Collection from "@figshare/ui/icons/presentation/collection";
-import Exclamation from "@figshare/ui/icons/presentation/exclamation";
-import CheckMark from "@figshare/ui/icons/presentation/checkMark";
-import Note from "@figshare/ui/icons/presentation/note";
-import FTP from "@figshare/ui/icons/presentation/ftp";
-import EnvelopeSuccess from "@figshare/ui/icons/presentation/envelopeSuccess";
-import EnvelopeError from "@figshare/ui/icons/presentation/envelopeError";
-import EmbedCode from "@figshare/ui/icons/presentation/embedCode";
-import EmbedTitle from "@figshare/ui/icons/presentation/embedTitle";
-import Ribbon from "@figshare/ui/icons/presentation/ribbon";
-import Publications from "@figshare/ui/icons/presentation/publications";
+import Quote from "@figshare/fcl/icons/presentation/quote";
+import Project from "@figshare/fcl/icons/presentation/project";
+import Collection from "@figshare/fcl/icons/presentation/collection";
+import Exclamation from "@figshare/fcl/icons/presentation/exclamation";
+import CheckMark from "@figshare/fcl/icons/presentation/checkMark";
+import Note from "@figshare/fcl/icons/presentation/note";
+import FTP from "@figshare/fcl/icons/presentation/ftp";
+import EnvelopeSuccess from "@figshare/fcl/icons/presentation/envelopeSuccess";
+import EnvelopeError from "@figshare/fcl/icons/presentation/envelopeError";
+import EmbedCode from "@figshare/fcl/icons/presentation/embedCode";
+import EmbedTitle from "@figshare/fcl/icons/presentation/embedTitle";
+import Ribbon from "@figshare/fcl/icons/presentation/ribbon";
+import Publications from "@figshare/fcl/icons/presentation/publications";
 
 <Quote />
 <Project />

--- a/stories/input/checkbox/checkbox.stories.mdx
+++ b/stories/input/checkbox/checkbox.stories.mdx
@@ -1,8 +1,8 @@
 import { useState, useCallback } from 'react';
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import TextInput from "@figshare/ui/input/text";
-import Checkbox from "@figshare/ui/input/checkbox";
-import Input from "@figshare/ui/input";
+import TextInput from "@figshare/fcl/input/text";
+import Checkbox from "@figshare/fcl/input/checkbox";
+import Input from "@figshare/fcl/input";
 
 <Meta 
   title="UI/Inputs/Checkbox" 

--- a/stories/input/date/index.stories.mdx
+++ b/stories/input/date/index.stories.mdx
@@ -1,8 +1,8 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
 
-import uncontrollable from "@figshare/ui/helpers/uncontrollable";
-import DatePickerComponent from "@figshare/ui/input/date/index";
-import InputComponent from '@figshare/ui/input/index';
+import uncontrollable from "@figshare/fcl/helpers/uncontrollable";
+import DatePickerComponent from "@figshare/fcl/input/date/index";
+import InputComponent from '@figshare/fcl/input/index';
 
 export const DatePicker = uncontrollable(
   DatePickerComponent,

--- a/stories/input/password/index.stories.mdx
+++ b/stories/input/password/index.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import PasswordInput from "@figshare/ui/input/password";
+import PasswordInput from "@figshare/fcl/input/password";
 
 <Meta 
   title="UI/Inputs/Password" 

--- a/stories/input/search/index.stories.mdx
+++ b/stories/input/search/index.stories.mdx
@@ -1,7 +1,7 @@
 
 import { useState, useCallback } from 'react';
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import SearchInput from "@figshare/ui/input/search";
+import SearchInput from "@figshare/fcl/input/search";
 
 <Meta 
   title="UI/Inputs/Search" 
@@ -50,7 +50,7 @@ Can be imported standalone or as a variation of the `Input` component:
 
 ```jsx
 import SearchInput from "@figshare/fcl/input/search";
-import Input from "@figshare/ui/input";
+import Input from "@figshare/fcl/input";
 
 const Query = ({ handleQuerySubmission }) => {
     const [query, setQuery] = useState("");

--- a/stories/input/text/index.stories.mdx
+++ b/stories/input/text/index.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import TextInput from "@figshare/ui/input/text";
-import Input from "@figshare/ui/input";
+import TextInput from "@figshare/fcl/input/text";
+import Input from "@figshare/fcl/input";
 
 <Meta 
   title="UI/Inputs/Text" 

--- a/stories/navigableList/navigableList.stories.mdx
+++ b/stories/navigableList/navigableList.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import NavigableList from "@figshare/ui/helpers/navigableList";
+import NavigableList from "@figshare/fcl/helpers/navigableList";
 
 <Meta 
   title="UI/NavigableList" 

--- a/stories/overlay/overlay.stories.mdx
+++ b/stories/overlay/overlay.stories.mdx
@@ -1,9 +1,9 @@
 import { useState, useMemo } from "react";
 import { Meta, Canvas, Story, ArgsTable } from "@storybook/addon-docs/blocks";
-import {Button} from '@figshare/ui/button';
-import {Input} from '@figshare/ui/input';
-import { Overlay, OverlayHeader, OverlayFooter, OverlayContent } from "@figshare/ui/overlay";
-import Toggletip, { Trigger, Content, UncontrolledToggletip } from "@figshare/ui/toggletip";
+import {Button} from '@figshare/fcl/button';
+import {Input} from '@figshare/fcl/input';
+import { Overlay, OverlayHeader, OverlayFooter, OverlayContent } from "@figshare/fcl/overlay";
+import Toggletip, { Trigger, Content, UncontrolledToggletip } from "@figshare/fcl/toggletip";
 
 import style from './overlay.stories.css';
 

--- a/stories/textEditor/index.stories.mdx
+++ b/stories/textEditor/index.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Canvas, Story, ArgsTable } from '@storybook/addon-docs/blocks';
 
-import TextEditor from "@figshare/ui/textEditor";
+import TextEditor from "@figshare/fcl/textEditor";
 
 import styles from "./index.stories.css";
 

--- a/stories/textarea/index.stories.mdx
+++ b/stories/textarea/index.stories.mdx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from "react";
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import Textarea from "@figshare/ui/textarea";
+import Textarea from "@figshare/fcl/textarea";
 
 export const ControlledTextarea = (props) => {
   const [value, setValue] = useState("");

--- a/stories/toggletip/index.stories.mdx
+++ b/stories/toggletip/index.stories.mdx
@@ -1,8 +1,8 @@
 import { useState, useCallback } from 'react';
 import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
-import Info from "@figshare/ui/icons/info/medium";
+import Info from "@figshare/fcl/icons/info/medium";
 
-import Toggletip, { Trigger, Content, UncontrolledToggletip } from "@figshare/ui/toggletip";
+import Toggletip, { Trigger, Content, UncontrolledToggletip } from "@figshare/fcl/toggletip";
 
 <Meta
   component={Toggletip}


### PR DESCRIPTION
- use new `@figshare/fcl` namespace for component imports and aliases for ui package.
- remove `/ui` namespace.