### PR TITLE
FIG-29754: adding fieldError and formAlerts components, adding -icon-warning color

### DIFF
--- a/packages/ui/alert/index.css
+++ b/packages/ui/alert/index.css
@@ -1,0 +1,41 @@
+.alert {
+  font-size: var(--typography-M-fontSize);
+  line-height: var(--typography-M-lineHeight);
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  padding-top: calc(1.5 * var(--gridSize));
+  padding-bottom: calc(1.5 * var(--gridSize));
+
+  color: var(--color-typography-primary);
+}
+
+.childContainer {
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.warning {
+  background-color: var(--color-layout-warning-background);
+}
+
+.success {
+  background-color: var(--color-layout-success-background);
+}
+
+.error {
+  background-color: var(--color-layout-error-background);
+}
+
+.close {
+  width: calc(6 * var(--gridSize));
+  height: calc(6 * var(--gridSize));
+
+  margin-right: calc(3 * var(--gridSize));
+}
+
+.closeIcon {
+  fill: inherit;
+}

--- a/packages/ui/alert/index.jsx
+++ b/packages/ui/alert/index.jsx
@@ -1,0 +1,67 @@
+import classnames from "classnames";
+import PropTypes from "prop-types";
+import React, { Component } from "react";
+
+import withRef from "../helpers/withRef";
+import Cancel from "../icons/cancel/medium";
+import { Button } from "../button";
+
+import styles from "./index.css";
+
+
+const variantStyles = {
+  error: styles.error,
+  success: styles.success,
+  warning: styles.warning,
+};
+
+class Alert extends Component {
+  static propTypes = {
+    children: PropTypes.func.isRequired,
+    variant: PropTypes.oneOf(Object.keys(variantStyles)).isRequired,
+    className: PropTypes.string,
+    forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    role: PropTypes.string,
+    onClose: PropTypes.func,
+  }
+
+  static defaultProps = {
+    className: undefined,
+    role: "alert",
+    onClose: undefined,
+    forwardedRef: null,
+  }
+
+  render() {
+    const { className, children, variant, role, onClose, forwardedRef, ...divProps } = this.props;
+
+    return (
+      <div
+        ref={forwardedRef}
+        className={classnames(styles.alert, variantStyles[variant], className)}
+        role={role}
+        {...divProps}
+      >
+        <div className={styles.childContainer}>
+          {children({ onClose })}
+        </div>
+        {this.renderCloseButton()}
+      </div>
+    );
+  }
+
+  renderCloseButton() {
+    const { onClose } = this.props;
+    if (!onClose) {
+      return null;
+    }
+
+    return (
+      <Button className={styles.close} onClick={onClose}>
+        <Cancel className={styles.closeIcon} />
+      </Button>
+    );
+  }
+}
+
+export default withRef(Alert);

--- a/packages/ui/alert/index.test.jsx
+++ b/packages/ui/alert/index.test.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import Alert from "./index";
+
+
+describe("<Alert />", () => {
+  it("render children", () => {
+    const children = jest.fn(() => (<div id="children">text</div>));
+    const alert = shallow(<Alert variant="success">{children}</Alert>).dive().dive();
+
+    expect(alert.find("#children")).toHaveLength(1);
+    expect(alert.find(".success")).toHaveLength(1);
+    expect(alert.props().role).toEqual("alert");
+  });
+
+  it("render children with close button", () => {
+    const children = jest.fn(() => (<div id="children">text</div>));
+
+    const closeFn = jest.fn();
+    const alert = shallow(<Alert role="alertdialog" variant="error" onClose={closeFn}>{children}</Alert>).dive().dive();
+
+    expect(alert.find("#children")).toHaveLength(1);
+    expect(alert.find(".error")).toHaveLength(1);
+    expect(alert.find(".close")).toHaveLength(1);
+    expect(alert.props().role).toEqual("alertdialog");
+
+
+    alert.find(".close").simulate("click");
+    expect(closeFn).toHaveBeenCalled();
+  });
+});

--- a/packages/ui/fieldError/fieldError.css
+++ b/packages/ui/fieldError/fieldError.css
@@ -1,0 +1,91 @@
+.fieldError {
+  position: relative;
+
+  box-sizing: border-box;
+  width: 100%;
+  max-width: calc(100% - var(--gridSize));
+  margin: 0 auto;
+}
+
+.small {
+  --font-size: var(--typography-S-fontSize);
+  --line-height: var(--typography-S-lineHeight);
+  --icon-width: var(--typography-S-fontSize);
+}
+
+.large {
+  --font-size: var(--typography-M-fontSize);
+  --line-height: var(--typography-M-lineHeight);
+  --icon-width: var(--typography-L-fontSize);
+}
+
+.valid {
+  visibility: hidden;
+  overflow: hidden;
+
+  max-height: 0;
+
+  transition: max-height 0.3s cubic-bezier(0, 0, 0, 1);
+}
+
+.invalid {
+  visibility: visible;
+
+  max-height: calc(100 * var(--gridSize));
+
+  transition: max-height 0.3s cubic-bezier(0.3, 0, 1, 1);
+}
+
+.errorEntry {
+  font-size: var(--font-size);
+  line-height: var(--line-height);
+
+  display: flex;
+  flex-direction: row;
+
+  padding: calc(1 * var(--gridSize)) calc(2 * var(--gridSize));
+
+  background-color: var(--color-layout-error-background);
+
+  justify-content: space-between;
+  align-items: center;
+}
+
+.errorEntry > div {
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.errorEntry svg {
+  width: var(--icon-width);
+  height: auto;
+}
+
+.warningIcon {
+  flex-shrink: 0;
+
+  fill: var(--color-icon-error);
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .valid {
+    visibility: hidden;
+    overflow: hidden;
+
+    max-height: 0;
+
+    transition: none;
+  }
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .invalid {
+    visibility: visible;
+
+    height: calc(6 * var(--gridSize));
+
+    max-height: calc(100 * var(--gridSize));
+
+    transition: none;
+  }
+}

--- a/packages/ui/fieldError/fieldError.jsx
+++ b/packages/ui/fieldError/fieldError.jsx
@@ -1,0 +1,82 @@
+import React, { useMemo } from "react";
+import classnames from "classnames";
+import { node, string, shape, oneOf } from "prop-types";
+
+import Warning from "../icons/warning/medium";
+
+// eslint-disable-next-line css-modules/no-unused-class
+import styles from "./fieldError.css";
+
+
+export function FieldError({ error, field, size, className }) {
+  const message = error?.message;
+  const id = error?.id;
+  const valid = useMemo(() => {
+    if (message) {
+      return false;
+    }
+
+    return true;
+  }, [id, message]);
+
+  const descriptor = useMemo(() => {
+    if (message) {
+      return { ...error, message };
+    }
+
+    return { at: "none", message: "" };
+  }, [message, field]);
+
+  return (
+    <div
+      className={classnames(styles.fieldError, styles[size], valid ? styles.valid : styles.invalid, className)}
+      data-error={!valid}
+      data-error-at={descriptor.at}
+      data-error-for={field}
+      data-error-id={id}
+    >
+      <div className={styles.errorEntry}>
+        {!valid && <div>{message}</div>}
+        <Warning className={styles.warningIcon} />
+      </div>
+    </div>
+  );
+}
+
+FieldError.propTypes = {
+  /**
+   * Optional class name to append to the field error node
+   */
+  className: string,
+  /**
+   * Object describing the field error that we want to display.
+   */
+  error: shape({
+    /**
+     * Information about the error, when or why it happened.
+     * Can be simply stated as: "blur"/"change"/"submit"
+     */
+    at: string,
+    /**
+     * Error message contents to display.
+     */
+    message: node,
+    /**
+     * Unique id for this particular error instance
+     */
+    id: string,
+  }),
+  /**
+   * Unique id of the field this error is linked to.
+   */
+  field: string,
+  /**
+   * Size variant for the field error.
+   * Recommended use: "small" for overlay forms and "large" for full page forms.
+   */
+  size: oneOf(["small", "large"]),
+};
+
+FieldError.defaultProps = { className: undefined, field: "unknown", error: undefined, size: "small" };
+
+export default FieldError;

--- a/packages/ui/fieldError/fieldError.test.jsx
+++ b/packages/ui/fieldError/fieldError.test.jsx
@@ -1,0 +1,50 @@
+import { mount, shallow } from "enzyme";
+import React from "react";
+
+import { FieldError } from "./fieldError";
+
+
+describe("<FieldError />", () => {
+  it("renders a field error if provided", () => {
+    const component = mount(
+      <FieldError
+        error={ {
+          id: "error-1",
+          at: "blur",
+          message: "message",
+        } } field="my-field"
+      />
+    );
+
+    const error = component.find(".fieldError").getDOMNode();
+
+    expect(error.getAttribute("data-error")).toEqual("true");
+    expect(error.getAttribute("data-error-at")).toEqual("blur");
+    expect(error.getAttribute("data-error-for")).toEqual("my-field");
+    expect(error.getAttribute("data-error-id")).toEqual("error-1");
+
+    component.unmount();
+  });
+  it("renders an empty field error message if none is provided (prevents focus steal issues with rerendering)", () => {
+    const component = mount(<FieldError error={null} />);
+
+    const error = component.find(".fieldError").getDOMNode();
+
+    expect(error.getAttribute("data-error")).toEqual("false");
+    expect(error.getAttribute("data-error-at")).toEqual("none");
+    expect(error.getAttribute("data-error-for")).toEqual("unknown");
+    expect(error.getAttribute("data-error-id")).toEqual(null);
+
+    component.unmount();
+  });
+
+  it("supports a couple of sizes", () => {
+    const defaultSmall = shallow(<FieldError error={null} />);
+    const small = shallow(<FieldError error={null} size="small" />);
+    const large = shallow(<FieldError error={null} size="large" />);
+
+    expect(defaultSmall.find(".small")).toHaveLength(1);
+    expect(small.find(".small")).toHaveLength(1);
+    expect(large.find(".large")).toHaveLength(1);
+  });
+});

--- a/packages/ui/fieldError/index.jsx
+++ b/packages/ui/fieldError/index.jsx
@@ -1,0 +1,1 @@
+export * from "./fieldError";

--- a/packages/ui/formAlerts/formAlerts.css
+++ b/packages/ui/formAlerts/formAlerts.css
@@ -1,0 +1,148 @@
+.alerts {
+  display: flex;
+  flex-direction: column;
+
+  width: 100%;
+  flex: 1 0;
+  gap: calc(2 * var(--gridSize));
+
+  margin-bottom: calc(3 * var(--gridSize));
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .empty {
+    overflow: hidden;
+
+    max-height: 0;
+
+    transition: none;
+    transition-timing-function: cubic-bezier(0, 0, 0, 1);
+
+    opacity: 0;
+  }
+}
+
+.empty {
+  overflow: hidden;
+
+  max-height: 0;
+
+  margin-bottom: 0;
+
+  transition: max-height 0.3s, opacity 0.3s;
+  transition-timing-function: cubic-bezier(0, 0, 0, 1);
+
+  opacity: 0;
+}
+
+@media screen and (prefers-reduced-motion: reduce) {
+  .shown {
+    max-height: calc(100 * var(--gridSize));
+
+    transition: none;
+    transition-timing-function: cubic-bezier(0.3, 0, 1, 1);
+
+    opacity: 1;
+  }
+}
+
+.shown {
+  max-height: calc(100 * var(--gridSize));
+
+  transition: max-height 0.3s, opacity 0.3s;
+  transition-timing-function: cubic-bezier(0.3, 0, 1, 1);
+
+  opacity: 1;
+}
+
+.alert {
+  --color-icon: currentcolor;
+
+  width: 100%;
+
+  margin: 0;
+  padding: 0;
+}
+
+.success {
+  --color-icon: var(--color-icon-success);
+}
+
+.error {
+  --color-icon: var(--color-icon-error);
+}
+
+.warning {
+  --color-icon: var(--color-icon-warning);
+}
+
+div.alert {
+  padding: 0;
+}
+
+.alert > div {
+  position: relative;
+
+  display: flex;
+  flex-direction: row;
+
+  width: 100%;
+  margin: 0;
+
+  padding: calc(2 * var(--gridSize));
+  gap: var(--gridSize);
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.alertIcon {
+  position: relative;
+
+  display: inline-flex;
+
+  width: calc(3 * var(--gridSize));
+  min-width: calc(3 * var(--gridSize));
+  max-width: calc(3 * var(--gridSize));
+  height: calc(3 * var(--gridSize));
+  max-height: calc(3 * var(--gridSize));
+
+  align-items: center;
+  justify-content: center;
+  fill: var(--color-icon);
+}
+
+.alertIcon > svg {
+  width: 100%;
+  max-width: 100%;
+
+  color: inherit;
+  fill: inherit;
+}
+
+.error .alertIcon {
+  margin-top: calc(var(--gridSize) / 3);
+}
+
+.warning .alertIcon {
+  margin-top: calc(var(--gridSize) / 2);
+}
+
+.warning .alertIcon > svg {
+  transform: rotate(180deg);
+}
+
+.success .alertIcon {
+  margin-top: calc(var(--gridSize) / 2);
+}
+
+.alertText {
+  font-size: var(--typography-M-fontSize);
+  line-height: var(--typography-M-lineHeight);
+}
+
+.alertClose {
+  width: calc(3 * var(--gridSize));
+  height: calc(3 * var(--gridSize));
+  margin-right: 0;
+  margin-left: auto;
+}

--- a/packages/ui/formAlerts/formAlerts.jsx
+++ b/packages/ui/formAlerts/formAlerts.jsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { string } from "prop-types";
+
+import { IconButton } from "../button";
+import Alert from "../alert";
+import Info from "../icons/info/small";
+import Warning from "../icons/warning/small";
+import Close from "../icons/cancel/medium";
+import Checkmark from "../icons/checkMark/small";
+
+// eslint-disable-next-line css-modules/no-unused-class
+import styles from "./formAlerts.css";
+import { popFormAlert } from "./utils";
+
+
+const IconsByType = {
+  error: Warning,
+  warning: Info,
+  success: Checkmark,
+};
+
+export class FormAlerts extends React.PureComponent {
+  static propTypes = {
+    /**
+     * The unique id for this alerts component.
+     * Will represent the `channel` used to listen to form alert messages.
+     */
+    id: string.isRequired,
+  }
+
+  static defaultProps = { id: "global-alerts" }
+
+  state = { messages: [], id: this.props.id }
+
+  componentDidMount() {
+    document.addEventListener("form-alerts:message", this.onWarningEvent);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener("form-alerts:message", this.onWarningEvent);
+  }
+
+  render() {
+    const { messages } = this.state;
+
+    const empty = !messages?.length;
+
+    return (
+      <div className={`${styles.alerts} ${empty ? styles.empty : styles.shown}`}>
+        {messages.map(this.renderAlert)}
+      </div>
+    );
+  }
+
+  renderAlert = (alert) => {
+    const { id, type, content } = alert;
+    const Icon = IconsByType[type];
+
+    return (
+      <Alert
+        key={id}
+        className={`${styles.alert} ${styles[type]}`}
+        data-id={`form-alert:${this.state.id}-${id}`}
+        variant={type}
+      >
+        {() => (<>
+          <div className={styles.alertIcon}><Icon /></div>
+          <div className={styles.alertText}>{content}</div>
+          <IconButton
+            Icon={Close}
+            className={styles.alertClose}
+            data-control-id="form-alert-close-button"
+            theme="tertiary"
+            onClick={this.onHideAlert(alert)}
+          />
+        </>)}
+      </Alert>
+    );
+  }
+
+  onWarningEvent = (event) => {
+    const { id: componentChannel, messages } = this.state;
+    const { detail: { action, message, channel, timeout } } = event;
+
+    if (channel !== componentChannel) {
+      return;
+    }
+
+    switch (action) {
+      case "push":
+        this.setState({ messages: [message] });
+
+        if (typeof timeout === "number") {
+          const id = message?.id;
+
+          setTimeout(() => {
+            popFormAlert(componentChannel, id);
+          }, [timeout]);
+        }
+        break;
+      case "clear":
+        this.setState({ messages: [] });
+        break;
+      case "pop": {
+        const index = messages.findIndex((m) => message?.id === m.id);
+
+        if (index !== 1) {
+          const newMessages = messages.slice();
+          newMessages.splice(index, 1);
+
+          this.setState({ messages: newMessages });
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  onHideAlert = (alert) => () => {
+    const { id: componentChannel } = this.state;
+
+    popFormAlert(componentChannel, alert.id);
+  }
+}
+

--- a/packages/ui/formAlerts/index.jsx
+++ b/packages/ui/formAlerts/index.jsx
@@ -1,0 +1,2 @@
+export * from "./formAlerts";
+export * from "./utils";

--- a/packages/ui/formAlerts/index.test.jsx
+++ b/packages/ui/formAlerts/index.test.jsx
@@ -1,0 +1,185 @@
+import { mount } from "enzyme";
+import React from "react";
+import { act } from "react-dom/test-utils";
+
+import { FormAlerts, pushFormAlert, popFormAlert, clearFormAlerts } from "./index";
+
+
+const DEFAULT_DELAY = 200;
+
+const wait = (resolution, rejection, delay = DEFAULT_DELAY) => act(() => new Promise((resolve, reject) => {
+  setTimeout(() => {
+    if (rejection !== undefined) {
+      reject(typeof rejection === "function" ? rejection() : rejection);
+    } else {
+      resolve(typeof resolution === "function" ? resolution() : resolution);
+    }
+  }, delay);
+}));
+
+describe("<FormAlerts />", () => {
+  it("renders a form alerts list node", () => {
+    const component = mount(
+      <FormAlerts id="alerts" />
+    );
+
+    expect(component.find(".alerts")).toHaveLength(1);
+    expect(component.find(".empty")).toHaveLength(1);
+
+    component.unmount();
+  });
+
+  it("subscribes to form-alerts:message, to push messages to it's own list", async() => {
+    const component = mount(
+      <FormAlerts id="alerts" />
+    );
+
+    expect(component.find(".alerts")).toHaveLength(1);
+    expect(component.find(".empty")).toHaveLength(1);
+
+    act(() => {
+      pushFormAlert({
+        channel: "alerts",
+        type: "warning",
+        content: "Some message",
+        identifier: "form-alert",
+      });
+
+      pushFormAlert({
+        channel: "wrong-channel",
+        type: "warning",
+        content: "Some message 2",
+        identifier: "form-alert",
+      });
+    });
+
+    await wait(component.update());
+
+
+    expect(component.find(".empty")).toHaveLength(0);
+    expect(component.find(".shown")).toHaveLength(1);
+    expect(component.find("div.alert.warning")).toHaveLength(1);
+
+    component.unmount();
+  });
+
+
+  it("subscribes to form-alerts:message, handles timeout if given", async() => {
+    const component = mount(
+      <FormAlerts id="alerts" />
+    );
+
+    expect(component.find(".alerts")).toHaveLength(1);
+    expect(component.find(".empty")).toHaveLength(1);
+    const timeout = 3000;
+
+    act(() => {
+      pushFormAlert({
+        channel: "wrong-channel",
+        type: "warning",
+        content: "Some message 2",
+        identifier: "form-alert",
+        timeout,
+      });
+    });
+    const timeoutBuffer = 1000;
+
+    await wait(() => component.update(), undefined, timeout + timeoutBuffer);
+
+
+    expect(component.find(".empty")).toHaveLength(1);
+    expect(component.find(".shown")).toHaveLength(0);
+
+    component.unmount();
+  });
+
+
+  it("subscribes to form-alerts:message, to pop one or clear all messages from it's own list", async() => {
+    const component = mount(
+      <FormAlerts id="alerts" />
+    );
+
+    expect(component.find(".alerts")).toHaveLength(1);
+    expect(component.find(".empty")).toHaveLength(1);
+
+    act(() => {
+      pushFormAlert({
+        channel: "alerts",
+        type: "warning",
+        content: "Some message",
+        identifier: "form-alert",
+      });
+    });
+
+    act(() => {
+      clearFormAlerts("alerts");
+    });
+
+    await wait(() => component.update());
+
+
+    expect(component.find(".empty")).toHaveLength(1);
+    expect(component.find(".shown")).toHaveLength(0);
+    expect(component.find("div.alert.warning")).toHaveLength(0);
+
+
+    act(() => {
+      pushFormAlert({
+        channel: "alerts",
+        type: "warning",
+        content: "Some message",
+        identifier: "form-alert-to-remove",
+      });
+      pushFormAlert({
+        channel: "alerts",
+        type: "warning",
+        content: "Some message",
+        identifier: "form-alert",
+      });
+    });
+
+    await wait(() => component.update());
+
+    act(() => {
+      popFormAlert("alerts", "not a match");
+    });
+
+    act(() => {
+      component.find("button.alertClose").at(0).simulate("click");
+    });
+
+    await wait(() => component.update());
+
+    expect(component.find(".empty")).toHaveLength(1);
+    expect(component.find("div.alert.warning")).toHaveLength(0);
+
+    component.unmount();
+  });
+
+
+  it("ignores unknown actions even if channel is ok", async() => {
+    const component = mount(
+      <FormAlerts id="alerts" />
+    );
+
+
+    act(() => {
+      const event = new CustomEvent("form-alerts:message", {
+        detail: {
+          action: "nothing registered",
+          channel: "alerts",
+        },
+      });
+
+      document.dispatchEvent(event);
+    });
+
+
+    await wait(() => component.update());
+
+    expect(component.find(".empty")).toHaveLength(1);
+    expect(component.find("div.alert.warning")).toHaveLength(0);
+
+    component.unmount();
+  });
+});

--- a/packages/ui/formAlerts/utils.jsx
+++ b/packages/ui/formAlerts/utils.jsx
@@ -1,0 +1,52 @@
+import uuid from "../helpers/utils/uuid";
+
+
+const defaultOptions = {
+  channel: "global-alerts",
+  type: "warning",
+  content: "Unknown message",
+  identifier: "form-alert",
+};
+
+export function pushFormAlert(options = {}) {
+  const config = { ...defaultOptions, ...options };
+  const { type, channel, content, identifier, timeout } = config;
+
+  const event = new CustomEvent("form-alerts:message", {
+    detail: {
+      action: "push",
+      channel,
+      timeout,
+      message: {
+        id: `${identifier}:${uuid()}`,
+        type,
+        content,
+      },
+    },
+  });
+
+  document.dispatchEvent(event);
+}
+
+export function clearFormAlerts(channel) {
+  const event = new CustomEvent("form-alerts:message", {
+    detail: {
+      action: "clear",
+      channel,
+    },
+  });
+
+  document.dispatchEvent(event);
+}
+
+export function popFormAlert(channel, id) {
+  const event = new CustomEvent("form-alerts:message", {
+    detail: {
+      action: "pop",
+      channel,
+      message: { id },
+    },
+  });
+
+  document.dispatchEvent(event);
+}

--- a/packages/ui/helpers/utils/compact.js
+++ b/packages/ui/helpers/utils/compact.js
@@ -1,0 +1,27 @@
+const Filters = {
+  "falsy": (value) => (value !== "") && (value !== undefined) && (value !== null) && (value !== 0),
+  "nullish": (value) => (value !== undefined) && (value !== null),
+};
+
+
+export function compact(collection, hasValue = Filters.falsy) {
+  if (Array.isArray(collection)) {
+    return collection.filter(hasValue);
+  }
+
+  if (typeof collection === "object" && collection !== null) {
+    return Object.entries(collection).reduce(((compacted, [key, value]) => {
+      if (hasValue(value)) {
+        compacted[key] = value;
+      }
+
+      return compacted;
+    }), {});
+  }
+
+  return collection;
+}
+
+compact.filters = Filters;
+
+export default compact;

--- a/packages/ui/helpers/utils/compact.test.js
+++ b/packages/ui/helpers/utils/compact.test.js
@@ -1,0 +1,22 @@
+import { compact } from "./compact";
+
+
+describe("compact(collection)", () => {
+  it("filters out falsy entries from arrays or objects", () => {
+    expect(compact([0, "", null, 10, undefined, "defined"])).toEqual([10, "defined"]);
+    expect(compact({ a: 0, b: "defined", c: null, d: "" })).toEqual({ b: "defined" });
+    expect(compact("")).toEqual("");
+    expect(compact(0)).toEqual(0);
+    expect(compact(1)).toEqual(1);
+    expect(compact(null)).toEqual(null);
+  });
+
+  it("accepts a filter function as a second argument, provides a set in 'compact.filters' ", () => {
+    expect(compact([0, "", null, 10, undefined, "defined"], compact.filters.nullish)).toEqual([0, "", 10, "defined"]);
+    expect(compact(
+      { a: 0, b: "defined", c: null, d: "" },
+      compact.filters.nullish)
+    ).toEqual({ a: 0, b: "defined", d: "" });
+    expect(compact("", compact.filters.nullish)).toEqual("");
+  });
+});

--- a/packages/ui/helpers/utils/uuid.js
+++ b/packages/ui/helpers/utils/uuid.js
@@ -1,0 +1,9 @@
+export function uuid() {
+  /* eslint-disable */
+  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
+    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+  );
+  /* eslint-enable */
+}
+
+export default uuid;

--- a/packages/ui/helpers/utils/uuid.test.js
+++ b/packages/ui/helpers/utils/uuid.test.js
@@ -1,0 +1,16 @@
+import { uuid } from "./uuid";
+
+
+describe("uuid utils", () => {
+  it("uuid() returns valid unique uuid strings", () => {
+    const one = uuid();
+    const two = uuid();
+    const three = uuid();
+
+    expect(typeof one).toEqual("string");
+    expect(typeof two).toEqual("string");
+    expect(typeof three).toEqual("string");
+    expect(one).not.toEqual(two);
+    expect(one).not.toEqual(three);
+  });
+});

--- a/packages/ui/styles/settings/colors.css
+++ b/packages/ui/styles/settings/colors.css
@@ -45,6 +45,7 @@
   --color-icon-success: #98b212;
   --color-icon-successAlt: #5fbdbb;
   --color-icon-error: #f00;
+  --color-icon-warning: #d16d11;
 
   /** Buttons **/
 

--- a/scripts/tests/jest.setup.js
+++ b/scripts/tests/jest.setup.js
@@ -2,10 +2,16 @@ import "core-js/stable";
 import "regenerator-runtime/runtime";
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
+import nodeCrypto from "crypto";
 
 
 Enzyme.configure({ adapter: new Adapter() });
 
+window.crypto = {
+  getRandomValues(buffer) {
+    return nodeCrypto.randomFillSync(buffer);
+  },
+};
 
 jest.mock(
   "@popperjs/core",

--- a/stories/alerts/fieldError.stories.mdx
+++ b/stories/alerts/fieldError.stories.mdx
@@ -1,0 +1,171 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import TextInput from "@figshare/fcl/input/text";
+import { FieldError } from "@figshare/fcl/fieldError";
+import { GenericButton } from "@figshare/fcl/button";
+
+export const schema = [
+  { type: "required", value: "string", at: ["blur"], message: "This field is required."  }, 
+  { type: "minlength", at: ["blur", "change"], limit: 3, message: "A minimum length of 3 characters is required." }
+];
+
+export const getRuleError = (value, at, rule) => {
+  const error = undefined;
+  if (!rule.at.includes(at)) { return undefined; }
+  switch (rule.type) {
+    case "required":
+      return value === "" ? rule.message : undefined;
+    case "minlength":
+      return value.length && value.length < rule.limit ? rule.message : undefined;
+    default:
+      return undefined;
+  }
+};
+
+export const validate = (value, at) => {
+  return schema.reduce((errors, rule) => {
+    const message = getRuleError(value, at, rule);
+    if (message) {
+      errors.push({ at, id: rule.type, message });
+    }
+    return errors;
+  }, []);
+};
+
+<Meta 
+  title="UI/Alerts/FieldError"
+  component={FieldError} 
+  parameters={{
+    viewMode: 'docs',
+    previewTabs: { 
+      canvas: { hidden: true } 
+     },
+  }}
+/>
+
+# FieldError
+---
+- [Overview](#overview)
+- [Props](#props-table)
+- [Examples](#examples)
+
+## Overview
+
+A field error component. Used to visually show error messages for form fields.
+
+<Story 
+  name="FieldError" 
+  parameters={{
+    layout: "centered",
+  }}
+>
+  {() => {
+    const [value, setValue] = useState("");
+    const [errors, setErrors] = useState([]);
+    const onChange = useCallback((event) => {
+      const newValue = event.target.value;
+      const newErrors = validate(newValue, "change");
+      setValue(newValue);
+      setErrors(newErrors);
+    }, [setValue, setErrors, validate]);
+    const onBlur = useCallback((event) => {
+      const { value } = event.target;
+      const newErrors = validate(value, "blur");
+      setErrors(newErrors);
+    }, [setErrors]);
+    return (
+      <div className="field-container" style={{ display: "flex", flexDirection: "column", width: "360px" }}>
+        <label htmlFor="form.field">Form field</label>
+        <TextInput id="form.field" name="form.field" placeholder="Input text..." onChange={onChange} onBlur={onBlur} error={!!errors.length} />
+        {errors.map(error => (
+          <FieldError key={error.id} error={error} field="form.field" />
+        ))}
+      </div>
+    )
+  }}
+</Story>
+
+Usually tied to inputs or other form fields in order to show various validation errors or messages. Focus or fill in the input to trigger validations and show any potential field errors.
+
+```jsx
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import TextInput from "@figshare/fcl/input/text";
+import { FieldError } from "@figshare/fcl/fieldError";
+
+const schema = [
+  { type: "required", value: "string", at: ["blur"], message: "This field is required."  }, 
+  { type: "minlength", at: ["change", "blur"], limit: 3, message: "A minimum length of 3 characters is required." }
+];
+
+export const getRuleError = (value, at, rule) => {
+  const error = undefined;
+  if (!rule.at.includes(at)) { return undefined; }
+  switch (rule.type) {
+    case "required":
+      return value === "" ? rule.message : undefined;
+    case "minlength":
+      return value.length && value.length < rule.limit ? rule.message : undefined;
+    default:
+      return undefined;
+  }
+};
+
+export const validate = (value, at) => {
+  return schema.reduce((errors, rule) => {
+    const message = getRuleError(value, at, rule);
+    if (message) {
+      errors.push({ at, id: rule.type, message });
+    }
+    return errors;
+  }, []);
+};
+
+export function ValidatedTextField() {
+  const [value, setValue] = useState("");
+  const [errors, setErrors] = useState([]);
+
+  const onChange = useCallback((event) => {
+    const newValue = event.target.value;
+    const newErrors = validate(newValue, "change");
+
+    setValue(newValue);
+    setErrors(newErrors);
+  }, [setValue, setErrors, validate]);
+
+  const onBlur = useCallback((event) => {
+    const { value } = event.target;
+    const newErrors = validate(value, "blur");
+
+    setErrors(newErrors);
+  }, [setErrors]);
+
+  return (
+    <div className="field-container" style={{ display: "flex", flexDirection: "column", width: "360px" }}>
+      <label htmlFor="form.field">Form field</label>
+      <TextInput id="form.field" name="form.field" placeholder="Input text..." onChange={onChange} onBlur={onBlur} error={!!errors.length} />
+      {errors.map(error => (
+        <FieldError key={error.id} error={error} field="form.field" />
+      ))}
+    </div>
+  );
+}
+```
+
+## Props Table
+<ArgsTable of={FieldError} />
+
+## Examples
+<Canvas>
+    <div style={{display: "flex", flexDirection: "column", gap: "18px"}}>
+      <code>size="small"</code>
+      <FieldError error={undefined} field="title" />
+      <FieldError error={{ at: "change", message: "Invalid character length", id: "description.maxlen" }} field="description" />
+      <FieldError error={{ at: "blur", message: "This field is required.", id: "references.required" }} field="references" />
+      <FieldError error={{ at: "submit/publish", message: <><span>Cannot publish with missing information. </span><GenericButton>Publish anyway.</GenericButton></>, id: "resources.required" }} field="resources" />
+      <code>size="large"</code>
+      <FieldError size="large" error={{ at: "change", message: "Invalid character length", id: "description.maxlen" }} field="description" />
+      <FieldError size="large" error={{ at: "blur", message: "This field is required.", id: "references.required" }} field="references" />
+      <FieldError size="large" error={{ at: "submit/publish", message: <><span>Cannot publish with missing information. </span><GenericButton>Publish anyway.</GenericButton></>, id: "resources.required" }} field="resources" />
+    </div>
+</Canvas>

--- a/stories/alerts/formAlerts.stories.mdx
+++ b/stories/alerts/formAlerts.stories.mdx
@@ -1,0 +1,124 @@
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { Meta, Story, Canvas, ArgsTable } from '@storybook/addon-docs/blocks';
+import { FormAlerts, pushFormAlert, clearFormAlerts } from "@figshare/fcl/formAlerts";
+import { Button } from "@figshare/fcl/button";
+
+<Meta 
+  title="UI/Alerts/FormAlerts"
+  component={FormAlerts} 
+  parameters={{
+    viewMode: 'docs',
+    previewTabs: { 
+      canvas: { hidden: true } 
+     },
+  }}
+/>
+
+# FormAlerts
+---
+- [Overview](#overview)
+- [Props](#props-table)
+- [Examples](#examples)
+
+## Overview
+
+An inline form alerts manager component. Holds a list of alert message entries and renders them.
+Messages can be added or removed by dispatching `"form-alerts:message"` type events.
+The module exports utilities to easily dispatch such events.
+
+<Story 
+  name="FormAlerts" 
+  parameters={{
+    layout: "centered",
+  }}
+>
+  {() => {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+        <div style={{ display: "flex", flexDirection: "row", gap: "12px" }}>
+          <Button theme="secondary" onClick={() => pushFormAlert({ channel: "alerts-channel", content: "Something is wrong.", type: "error" })}>Push Error</Button>
+          <Button theme="secondary" onClick={() => pushFormAlert({ channel: "alerts-channel", content: "Something is not ok.", type: "warning" })}>Push Warning</Button>
+          <Button theme="secondary" onClick={() => pushFormAlert({ channel: "alerts-channel", content: "All is well.", type: "success" })}>Push success</Button>
+          <Button theme="secondary" onClick={() => clearFormAlerts("alerts-channel")}>Clear</Button>
+        </div>
+      <div className="field-container" style={{ display: "flex", flexDirection: "column", width: "50%" }}>
+        <FormAlerts id="alerts-channel" />
+      </div>
+      </div>
+    )
+  }}
+</Story>
+
+The component and utilities can be imported from `@figshare/fcl/formAlerts`.
+See the example below on how to register a form alerts component and `push` or `clear` form alerts for it.
+
+
+```jsx
+import React, { useState, useEffect, useCallback, useMemo } from "react";
+import TextInput from "@figshare/fcl/input/text";
+import { FormAlerts, pushFormAlert, clearFormAlerts } from "@figshare/fcl/formAlerts";
+
+function AlertsExample() {
+  const [description, setDescription] = useState("");
+
+  const onSubmit = useCallback(async (event) => {
+    clearFormAlerts("description-update-form-alerts-channel");
+
+    try {
+      await backendAPI(description);
+
+      pushFormAlert({
+        type: "success",
+        content: "Updated description."
+        channel: "description-update-form-alerts-channel"
+      });
+    } catch (e) {
+      pushFormAlert({
+        type: "error",
+        content: `Some error occured. ${e.message}`,
+        channel: "description-update-form-alerts-channel" 
+      });
+    }
+  }, [description]);
+  const onReset = useCallback(async (event) => {
+      setDescription("");
+      pushFormAlert({
+        type: "warning",
+        content: "Cleared form.",
+        channel: "description-update-form-alerts-channel",
+        timeout: 2000
+    });
+  }, [setDescription]);
+
+    return (
+      <form data-form-id="description-update-form" onReset={onReset} onSubmit={onSubmit}>
+        <FormAlerts id="description-update-form-alerts-channel" />
+        <div className="fields" style={{ display: "flex", flexDirection: "column", width: "50%" }}>
+          <TextInput type="text" onChange={e => setInput(e.target.value)} name="description" />
+        </div>
+        <div className="controls">
+          <Button theme="primary" type="reset">Clear</Button>
+          <Button theme="primary" type="submit">Submit</Button>
+        </div>
+      </form>
+    );
+}
+```
+
+## Props Table
+<ArgsTable of={FormAlerts} />
+
+## Examples
+<Canvas>
+    <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+      <div style={{ display: "flex", flexDirection: "row", gap: "12px" }}>
+        <Button theme="secondary" onClick={() => pushFormAlert({ channel: "alerts-channel", content: "Something is wrong.", type: "error" })}>Push Error</Button>
+        <Button theme="secondary" onClick={() => pushFormAlert({ channel: "alerts-channel", content: "Something is not ok.", type: "warning" })}>Push Warning</Button>
+        <Button theme="secondary" onClick={() => pushFormAlert({ channel: "alerts-channel", content: "All is well.", type: "success" })}>Push success</Button>
+        <Button theme="secondary" onClick={() => clearFormAlerts("alerts-channel")}>Clear</Button>
+      </div>
+    <div className="field-container" style={{ display: "flex", flexDirection: "column", width: "50%" }}>
+      <FormAlerts id="alerts-channel" />
+    </div>
+    </div>
+</Canvas>


### PR DESCRIPTION
- **New:** `FieldError` component 
> used to display errors for field components
 
![Screenshot 2023-04-27 at 11 11 58](https://user-images.githubusercontent.com/6098942/234800976-e51b9a33-4f1e-4adc-a3a6-ce4507ccd51b.png)

- **New:** `FormAlerts` component
> used to display alert messages (success, warning, error) for forms or other component groups.
![Screenshot 2023-04-27 at 11 13 34](https://user-images.githubusercontent.com/6098942/234801447-6d607059-9211-4f29-9cd5-0ad4c7e032a7.png)
![Screenshot 2023-04-27 at 11 13 36](https://user-images.githubusercontent.com/6098942/234801452-6eb20d0d-8fb4-42e9-b77d-db19f96c0856.png)
![Screenshot 2023-04-27 at 11 13 39](https://user-images.githubusercontent.com/6098942/234801454-bd1fc9f1-928f-43b0-8142-fe762b83a77a.png)

- **New** added `-icon-warning-color` to `styles/colors.css`.