### PR TITLE
FIG-30663: Alerts: noTypeIcon, and attributes support

### DIFF
--- a/packages/ui/alerts/alerts.css
+++ b/packages/ui/alerts/alerts.css
@@ -150,6 +150,8 @@ div.alert {
 }
 
 .alertText {
+  flex: 1 0;
+
   font-size: var(--typography-M-fontSize);
   line-height: var(--typography-M-lineHeight);
 }
@@ -159,4 +161,16 @@ div.alert {
   height: calc(3 * var(--gridSize));
   margin-right: 0;
   margin-left: auto;
+}
+
+/* stylelint-disable-next-line a11y/no-display-none */
+.noTypeIcon .alertIcon {
+  display: none;
+}
+
+.noTypeIcon .alertText {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 }

--- a/packages/ui/alerts/alerts.jsx
+++ b/packages/ui/alerts/alerts.jsx
@@ -21,6 +21,8 @@ const IconsByType = {
   info: Info,
 };
 
+const NO_ATTRIBUTES = {};
+
 export class Alerts extends React.PureComponent {
   static propTypes = {
     /**
@@ -29,12 +31,21 @@ export class Alerts extends React.PureComponent {
      */
     id: string.isRequired,
     /**
-      * Optional class to show Alerts at the viewport level.
+      * Optional className to append to the Alerts wrapper.
+    */
+    className: string,
+    /**
+      * Optional flag to show Alerts at the viewport level.
     */
     isFixed: bool,
+    /**
+      * Optional flag to hide Alert `type` icons.
+      * If true, content will also be visually centered.
+    */
+    noTypeIcon: bool,
   }
 
-  static defaultProps = { id: "global-alerts", isFixed: false }
+  static defaultProps = { id: "global-alerts", className: undefined, isFixed: false, noTypeIcon: false }
 
   state = { messages: [], id: this.props.id }
 
@@ -47,8 +58,8 @@ export class Alerts extends React.PureComponent {
   }
 
   render() {
-    const { messages } = this.state;
-    const { isFixed } = this.props;
+    const { id, messages } = this.state;
+    const { className, isFixed, noTypeIcon } = this.props;
 
     const empty = !messages?.length;
 
@@ -58,9 +69,15 @@ export class Alerts extends React.PureComponent {
           classnames(
             styles.alerts,
             empty ? styles.empty : styles.shown,
-            { [styles.isFixed]: isFixed },
+            {
+              [styles.isFixed]: isFixed,
+              [styles.noTypeIcon]: noTypeIcon,
+            },
+            className,
           )
         }
+        data-alerts-channel={id}
+        data-alerts-empty={empty}
       >
         {messages.map(this.renderAlert)}
       </div>
@@ -68,7 +85,7 @@ export class Alerts extends React.PureComponent {
   }
 
   renderAlert = (alert) => {
-    const { id, type, content } = alert;
+    const { id, type, content, attributes = NO_ATTRIBUTES } = alert;
     const Icon = IconsByType[type];
 
     return (
@@ -77,6 +94,8 @@ export class Alerts extends React.PureComponent {
         className={`${styles.alert} ${styles[type]}`}
         data-id={`form-alert:${this.state.id}-${id}`}
         variant={type}
+        {...attributes}
+        data-alert-type={type}
       >
         {() => (<>
           <div className={styles.alertIcon}><Icon /></div>

--- a/packages/ui/alerts/index.test.jsx
+++ b/packages/ui/alerts/index.test.jsx
@@ -40,6 +40,16 @@ describe("<Alerts />", () => {
     component.unmount();
   });
 
+  it("renders an alerts with no type icons if specified", () => {
+    const component = mount(
+      <Alerts id="alerts" noTypeIcon={true} />
+    );
+
+    expect(component.find(".noTypeIcon")).toHaveLength(1);
+
+    component.unmount();
+  });
+
   it("subscribes to form-alerts:message, to push messages to it's own list", async() => {
     const component = mount(
       <Alerts id="alerts" />
@@ -54,6 +64,7 @@ describe("<Alerts />", () => {
         type: "warning",
         content: "Some message",
         identifier: "form-alert",
+        attributes: { "data-custom-alert-attribute": "attribute-value" },
       });
 
       pushAlert({
@@ -70,6 +81,7 @@ describe("<Alerts />", () => {
     expect(component.find(".empty")).toHaveLength(0);
     expect(component.find(".shown")).toHaveLength(1);
     expect(component.find("div.alert.warning")).toHaveLength(1);
+    expect(component.find("div[data-custom-alert-attribute=\"attribute-value\"]")).toHaveLength(1);
 
     component.unmount();
   });

--- a/packages/ui/alerts/utils.jsx
+++ b/packages/ui/alerts/utils.jsx
@@ -11,7 +11,7 @@ const defaultOptions = {
 
 export function pushAlert(options = {}) {
   const config = { ...defaultOptions, ...options };
-  const { type, channel, content, persistent, identifier, timeout } = config;
+  const { type, channel, content, persistent, identifier, timeout, attributes } = config;
 
   const event = new CustomEvent("form-alerts:message", {
     detail: {
@@ -23,6 +23,7 @@ export function pushAlert(options = {}) {
         type,
         content,
         persistent,
+        attributes,
       },
     },
   });

--- a/stories/alerts/alerts.stories.mdx
+++ b/stories/alerts/alerts.stories.mdx
@@ -33,7 +33,8 @@ The module exports utilities to easily dispatch such events.
   }}
 >
   {() => {
-    const [fixed,setFixed] = useState(false);
+    const [fixed, setFixed] = useState(false);
+    const [noTypeIcon, setNoTypeIcon] = useState(false);
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
         <div style={{ display: "flex", flexDirection: "row", gap: "12px" }}>
@@ -43,14 +44,20 @@ The module exports utilities to easily dispatch such events.
           >
             {fixed ? "Show Inline" : "Show fixed to viewport"}
           </Button>
-          <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "Something is wrong.", type: "error" })}>Push Error</Button>
+          <Button
+            theme="secondary"
+            onClick={() => {setNoTypeIcon(!noTypeIcon)}}
+          >
+            {noTypeIcon ? "Show Type Icons" : "Hide Type Icons"}
+          </Button>
+          <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "Something is wrong.", type: "error", attributes: { "data-special-error": true } })}>Push Error</Button>
           <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "Something is not ok.", type: "warning" })}>Push Warning</Button>
           <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "All is well.", type: "success" })}>Push success</Button>
           <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "Info.", persistent: true, type: "info" })}>Push info</Button>
           <Button theme="secondary" onClick={() => clearAlerts("alerts-channel")}>Clear</Button>
         </div>
         <div className="field-container" style={{ display: "flex", flexDirection: "column", width: "50%" }}>
-        <Alerts id="alerts-channel" isFixed={fixed ? true : false}/>
+        <Alerts id="alerts-channel" isFixed={fixed} noTypeIcon={noTypeIcon}/>
         </div>
       </div>
     )


### PR DESCRIPTION
## Components
### Alerts
 - added `className` support for `Alerts` wrapper
 - added `noTypeIcon` prop, which hides `type` icons and `centers` `Alert` content.
 - added optional `attributes` support to `pushAlert`. will be passed to the `Alert` node if specified.
![Screenshot 2023-06-06 at 15 51 42](https://github.com/figshare/fcl/assets/6098942/013b0f1c-cbb5-4137-965e-ece9e470d764)
![Screenshot 2023-06-06 at 15 51 47](https://github.com/figshare/fcl/assets/6098942/287c4421-ed23-4360-bdf4-a5d1afa2f2db)
![Screenshot 2023-06-06 at 15 51 55](https://github.com/figshare/fcl/assets/6098942/dc53a5a7-ed99-4c79-a18e-28005a6dbef5)

 
 