### PR TITLE
FIG-30689: adding title and toast style support

### DIFF
--- a/packages/ui/alert/index.css
+++ b/packages/ui/alert/index.css
@@ -10,6 +10,7 @@
   padding-bottom: calc(1.5 * var(--gridSize));
 
   color: var(--color-typography-primary);
+  border-radius: var(--gridSize);
 }
 
 .childContainer {
@@ -30,7 +31,6 @@
 }
 
 .info {
-  border-radius: var(--gridSize);
   background-color: var(--color-layout-secondary-background);
 }
 

--- a/packages/ui/alerts/alerts.css
+++ b/packages/ui/alerts/alerts.css
@@ -1,4 +1,6 @@
 .alerts {
+  --corner-radius: var(--gridSize);
+
   display: flex;
   flex-direction: column;
 
@@ -10,6 +12,8 @@
 }
 
 .isFixed {
+  --corner-radius: 0;
+
   position: fixed;
   top: 0;
   left: 0;
@@ -68,6 +72,8 @@
 
   margin: 0;
   padding: 0;
+
+  border-radius: var(--corner-radius);
 }
 
 .success {
@@ -75,7 +81,7 @@
 }
 
 .error {
-  --color-icon: var(--color-icon-error);
+  --color-icon: var(--color-typography-error);
 }
 
 .warning {
@@ -88,6 +94,31 @@
 
 div.alert {
   padding: 0;
+}
+
+.isToast .alert {
+  position: relative;
+
+  background-color: var(--color-layout-background-primary) !important;
+  box-shadow: 2px 2px 7px 2px rgba(0, 0, 0, 0.14);
+}
+
+.isToast .alert::before {
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  width: var(--gridSize);
+  height: 100%;
+
+  content: "";
+
+  border-top-left-radius: var(--corner-radius);
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: var(--corner-radius);
+
+  background: var(--color-icon);
 }
 
 .alert > div {
@@ -103,6 +134,14 @@ div.alert {
   gap: var(--gridSize);
   align-items: flex-start;
   justify-content: flex-start;
+}
+
+.alert.withTitle > div {
+  flex-direction: column;
+}
+
+.isToast .alert > div {
+  padding-left: calc(3 * var(--gridSize));
 }
 
 .alertIcon {
@@ -161,6 +200,24 @@ div.alert {
   height: calc(3 * var(--gridSize));
   margin-right: 0;
   margin-left: auto;
+}
+
+.alertHeader {
+  display: flex;
+  flex-direction: row;
+
+  width: 100%;
+  min-width: 100%;
+  flex: 1 0;
+  gap: calc(2 * var(--gridSize));
+  justify-content: space-between;
+}
+
+.alertTitle {
+  display: flex;
+  flex-direction: row;
+  gap: calc(2 * var(--gridSize));
+  justify-content: flex-start;
 }
 
 /* stylelint-disable-next-line a11y/no-display-none */

--- a/packages/ui/alerts/alerts.jsx
+++ b/packages/ui/alerts/alerts.jsx
@@ -39,13 +39,17 @@ export class Alerts extends React.PureComponent {
     */
     isFixed: bool,
     /**
+      * Optional flag to show alerts as a toaster.
+    */
+    isToast: bool,
+    /**
       * Optional flag to hide Alert `type` icons.
       * If true, content will also be visually centered.
     */
     noTypeIcon: bool,
   }
 
-  static defaultProps = { id: "global-alerts", className: undefined, isFixed: false, noTypeIcon: false }
+  static defaultProps = { id: "global-alerts", className: undefined, isFixed: false, isToast: false, noTypeIcon: false }
 
   state = { messages: [], id: this.props.id }
 
@@ -59,7 +63,7 @@ export class Alerts extends React.PureComponent {
 
   render() {
     const { id, messages } = this.state;
-    const { className, isFixed, noTypeIcon } = this.props;
+    const { className, isFixed, isToast, noTypeIcon } = this.props;
 
     const empty = !messages?.length;
 
@@ -72,6 +76,7 @@ export class Alerts extends React.PureComponent {
             {
               [styles.isFixed]: isFixed,
               [styles.noTypeIcon]: noTypeIcon,
+              [styles.isToast]: isToast,
             },
             className,
           )
@@ -85,26 +90,47 @@ export class Alerts extends React.PureComponent {
   }
 
   renderAlert = (alert) => {
-    const { id, type, content, attributes = NO_ATTRIBUTES } = alert;
+    const { id, type, content, title, attributes = NO_ATTRIBUTES } = alert;
     const Icon = IconsByType[type];
+    const withTitle = !!title;
+    const renderer = () => {
+      if (withTitle) {
+        return this.renderContentAndTitle(Icon, title, content);
+      }
+
+      return this.renderContentOnly(Icon, content);
+    };
 
     return (
       <Alert
         key={id}
-        className={`${styles.alert} ${styles[type]}`}
+        className={classnames(styles.alert, styles[type], { [styles.withTitle]: withTitle })}
         data-id={`form-alert:${this.state.id}-${id}`}
         variant={type}
         {...attributes}
         data-alert-type={type}
       >
-        {() => (<>
-          <div className={styles.alertIcon}><Icon /></div>
-          <div className={styles.alertText}>{content}</div>
-          {this.renderCloseBtn(alert)}
-        </>)}
+        {renderer}
       </Alert>
     );
   }
+
+  renderContentOnly = (Icon, content) => (<>
+    <div className={styles.alertIcon}><Icon /></div>
+    <div className={styles.alertText}>{content}</div>
+    {this.renderCloseBtn(alert)}
+  </>);
+
+  renderContentAndTitle = (Icon, title, content) => (<>
+    <div className={styles.alertHeader}>
+      <div className={styles.alertTitle}>
+        <div className={styles.alertIcon}><Icon /></div>
+        <b>{title}</b>
+      </div>
+      {this.renderCloseBtn(alert)}
+    </div>
+    <div className={styles.alertText}>{content}</div>
+  </>);
 
   renderCloseBtn = (alert) => {
     const { persistent } = alert;

--- a/packages/ui/alerts/index.test.jsx
+++ b/packages/ui/alerts/index.test.jsx
@@ -50,6 +50,16 @@ describe("<Alerts />", () => {
     component.unmount();
   });
 
+  it("renders alerts with toast styling if specified", () => {
+    const component = mount(
+      <Alerts id="alerts" isToast={true} />
+    );
+
+    expect(component.find(".isToast")).toHaveLength(1);
+
+    component.unmount();
+  });
+
   it("subscribes to form-alerts:message, to push messages to it's own list", async() => {
     const component = mount(
       <Alerts id="alerts" />
@@ -204,6 +214,34 @@ describe("<Alerts />", () => {
 
     expect(component.find(".empty")).toHaveLength(1);
     expect(component.find("div.alert.warning")).toHaveLength(0);
+
+    component.unmount();
+  });
+  it("allows alerts to have titles or custom attributes", async() => {
+    const component = mount(
+      <Alerts id="alerts" />
+    );
+
+    expect(component.find(".alerts")).toHaveLength(1);
+    expect(component.find(".empty")).toHaveLength(1);
+
+    act(() => {
+      pushAlert({
+        channel: "alerts",
+        type: "warning",
+        content: "Some message",
+        title: "Some title",
+        identifier: "form-alert",
+        attributes: { "data-is-publish-alert": true },
+      });
+    });
+
+    await wait(() => component.update());
+
+    expect(component.find(".shown")).toHaveLength(1);
+    expect(component.find("div.alert.warning")).toHaveLength(1);
+    expect(component.find("div[data-is-publish-alert]")).toHaveLength(1);
+    expect(component.find("div.alertTitle")).toHaveLength(1);
 
     component.unmount();
   });

--- a/packages/ui/alerts/utils.jsx
+++ b/packages/ui/alerts/utils.jsx
@@ -11,7 +11,7 @@ const defaultOptions = {
 
 export function pushAlert(options = {}) {
   const config = { ...defaultOptions, ...options };
-  const { type, channel, content, persistent, identifier, timeout, attributes } = config;
+  const { type, channel, content, persistent, identifier, timeout, title, attributes } = config;
 
   const event = new CustomEvent("form-alerts:message", {
     detail: {
@@ -24,6 +24,7 @@ export function pushAlert(options = {}) {
         content,
         persistent,
         attributes,
+        title,
       },
     },
   });

--- a/stories/alerts/alerts.stories.mdx
+++ b/stories/alerts/alerts.stories.mdx
@@ -35,8 +35,10 @@ The module exports utilities to easily dispatch such events.
   {() => {
     const [fixed, setFixed] = useState(false);
     const [noTypeIcon, setNoTypeIcon] = useState(false);
+    const [isToast, setIsToast] = useState(false);
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+        <span>Change appearance:</span>
         <div style={{ display: "flex", flexDirection: "row", gap: "12px" }}>
           <Button
             theme="secondary"
@@ -50,14 +52,27 @@ The module exports utilities to easily dispatch such events.
           >
             {noTypeIcon ? "Show Type Icons" : "Hide Type Icons"}
           </Button>
-          <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "Something is wrong.", type: "error", attributes: { "data-special-error": true } })}>Push Error</Button>
-          <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "Something is not ok.", type: "warning" })}>Push Warning</Button>
-          <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "All is well.", type: "success" })}>Push success</Button>
-          <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "Info.", persistent: true, type: "info" })}>Push info</Button>
-          <Button theme="secondary" onClick={() => clearAlerts("alerts-channel")}>Clear</Button>
+          <Button
+            theme="secondary"
+            onClick={() => {setIsToast(!isToast)}}
+          >
+            {isToast ? "Normal" : "Toast"}
+          </Button>
+          <Button theme="secondary" onClick={() => clearAlerts("alerts-channel")}>Clear</Button>       
         </div>
-        <div className="field-container" style={{ display: "flex", flexDirection: "column", width: "50%" }}>
-        <Alerts id="alerts-channel" isFixed={fixed} noTypeIcon={noTypeIcon}/>
+        <span>Push alerts:</span>
+        <div style={{ display: "flex", flexDirection: "row", gap: "12px" }}>
+          <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "Something is wrong.", type: "error" })}>Error</Button>
+          <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "Something is not ok.", type: "warning" })}>Warning</Button>
+          <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "All is well.", type: "success" })}>Success</Button>
+          <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", content: "Information in this particular alert.", persistent: true, type: "info" })}>Info</Button>
+          <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", title: "Alert!", content: "Something is wrong.", type: "error", attributes: { "data-special-error": true } })}>Error + Title</Button>
+          <Button theme="secondary" onClick={() => pushAlert({ channel: "alerts-channel", title: "Please note:", content: "Information in this particular alert.", persistent: true, type: "info" })}>Info + Title</Button>
+        </div>
+        <div style={{ display: "flex", flexDirection: "row", gap: "12px" }}>
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", width: "50%" }}>
+        <Alerts id="alerts-channel" isFixed={fixed} noTypeIcon={noTypeIcon} isToast={isToast}/>
         </div>
       </div>
     )
@@ -118,6 +133,20 @@ function AlertsExample() {
       </form>
     );
 }
+```
+
+To push an alert to a registered `Alerts` channel, use the `pushAlert` function:
+```jsx
+  pushAlert({ 
+    channel: 'alerts-instance-id' // id value given to the Alerts instance we want to push to.
+    content: <b>Alert content</b> // content node with the message we want to display
+    type: "error" // type of alert we want to show
+    timeout: 1000 // number of miliseconds the alert should be shown. If not specified, the user will have to close it manually.
+    persistent: true // if specified as true, the X (close) button will not be shown for this particular alert.
+    title: <>Alert title (shown next to type icon)</> // optional title for this alert. Changes the layout of the alert.
+    attributes: { "data-attr": "value" } // optional attributes to pass on to the this particular alert node.
+    identifier: "custom-identifier-prefix" // value prefixed to the unique alert id for this push.
+  });
 ```
 
 ## Props Table


### PR DESCRIPTION
## Components
### Alerts
 - adding `title` support
 - adding `toast` support
![Screenshot 2023-06-08 at 14 46 21](https://github.com/figshare/fcl/assets/6098942/335826d5-4850-4a00-afb6-6a9d8d025471)

![Screenshot 2023-06-08 at 14 43 11](https://github.com/figshare/fcl/assets/6098942/41601033-b3a4-419f-814d-faa5d9817d2a)
![Screenshot 2023-06-08 at 14 43 14](https://github.com/figshare/fcl/assets/6098942/7db37dde-a763-408a-a414-05fd00940e3e)
