### PR TITLE
fixing toggletip propagation issue on react-17

### DIFF
--- a/packages/ui/toggletip/components/trigger/index.jsx
+++ b/packages/ui/toggletip/components/trigger/index.jsx
@@ -97,6 +97,8 @@ export default class Trigger extends Component {
       return;
     }
 
+    e?.stopPropagation?.();
+
     onClick?.(e);
     onToggle?.(e);
   }

--- a/packages/ui/toggletip/uncontrolled.jsx
+++ b/packages/ui/toggletip/uncontrolled.jsx
@@ -36,6 +36,8 @@ export default class UncontrolledToggletip extends Component {
   onToggle = (e) => {
     const { onToggle } = this.props;
 
+    e?.stopPropagation?.();
+
     this.setState((prevState) => {
       return { isVisible: !prevState.isVisible };
     }, () => onToggle?.(e, this.state.isVisible));


### PR DESCRIPTION
## Bugfix
### Toggletip
 - resolves an issue with react 17 where Toggletip -> Trigger `onToggle` functions are triggered multiple times.