### PR TITLE
Razvanantalut/text editor/updates

### DIFF
--- a/packages/ui/alerts/alerts.jsx
+++ b/packages/ui/alerts/alerts.jsx
@@ -95,10 +95,10 @@ export class Alerts extends React.PureComponent {
     const withTitle = !!title;
     const renderer = () => {
       if (withTitle) {
-        return this.renderContentAndTitle(Icon, title, content);
+        return this.renderContentAndTitle(Icon, title, content, alert);
       }
 
-      return this.renderContentOnly(Icon, content);
+      return this.renderContentOnly(Icon, content, alert);
     };
 
     return (
@@ -115,13 +115,13 @@ export class Alerts extends React.PureComponent {
     );
   }
 
-  renderContentOnly = (Icon, content) => (<>
+  renderContentOnly = (Icon, content, alert) => (<>
     <div className={styles.alertIcon}><Icon /></div>
     <div className={styles.alertText}>{content}</div>
     {this.renderCloseBtn(alert)}
   </>);
 
-  renderContentAndTitle = (Icon, title, content) => (<>
+  renderContentAndTitle = (Icon, title, content, alert) => (<>
     <div className={styles.alertHeader}>
       <div className={styles.alertTitle}>
         <div className={styles.alertIcon}><Icon /></div>

--- a/packages/ui/styles/generic/typography.css
+++ b/packages/ui/styles/generic/typography.css
@@ -124,3 +124,12 @@ ul:not([class]) ol:not([class]) ol:not([class]),
 ul:not([class]) ul:not([class]) ol:not([class]) {
   list-style-type: lower-alpha;
 }
+
+li:has(ol),
+li:has(ul) {
+  list-style: none;
+}
+
+li[data-indent] {
+  list-style: none;
+}

--- a/packages/ui/styles/generic/typography.css
+++ b/packages/ui/styles/generic/typography.css
@@ -30,7 +30,6 @@ ol {
 
 h1:not([class]) {
   font-size: var(--typography-XXL-fontSize);
-  font-weight: bold;
   line-height: var(--typography-XXL-lineHeight);
 
   margin: 0 0 calc(7 * var(--gridSize)) 0;
@@ -38,7 +37,6 @@ h1:not([class]) {
 
 h2:not([class]) {
   font-size: var(--typography-XL-fontSize);
-  font-weight: bold;
   line-height: var(--typography-XL-lineHeight);
 
   margin: calc(7 * var(--gridSize)) 0 calc(2 * var(--gridSize)) 0;
@@ -46,7 +44,6 @@ h2:not([class]) {
 
 h3:not([class]) {
   font-size: var(--typography-L-fontSize);
-  font-weight: bold;
   line-height: var(--typography-L-lineHeight);
 
   margin: calc(5 * var(--gridSize)) 0 calc(2 * var(--gridSize)) 0;
@@ -54,7 +51,6 @@ h3:not([class]) {
 
 h4:not([class]) {
   font-size: var(--typography-M-fontSize);
-  font-weight: bold;
   line-height: var(--typography-M-lineHeight);
 
   margin: calc(4 * var(--gridSize)) 0 calc(2 * var(--gridSize)) 0;
@@ -62,7 +58,6 @@ h4:not([class]) {
 
 h5:not([class]) {
   font-size: var(--typography-S-fontSize);
-  font-weight: bold;
   line-height: var(--typography-S-lineHeight);
 
   margin: calc(4 * var(--gridSize)) 0 calc(2 * var(--gridSize)) 0;
@@ -72,7 +67,6 @@ h5:not([class]) {
 
 h6:not([class]) {
   font-size: var(--typography-S-fontSize);
-  font-weight: bold;
   line-height: var(--typography-S-lineHeight);
 
   margin: calc(4 * var(--gridSize)) 0 calc(2 * var(--gridSize)) 0;

--- a/packages/ui/textEditor/Lexical/components/LinkEditor/LinkEditor.jsx
+++ b/packages/ui/textEditor/Lexical/components/LinkEditor/LinkEditor.jsx
@@ -11,7 +11,7 @@ import GoToLinkLarge from "@figshare/fcl/icons/goToLink/large";
 import LinkUnlinked from "@figshare/fcl/icons/link/unlinked";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 
-import { getSelectedNode, sanitizeUrl } from "./utils";
+import { getSelectedNode, sanitizeUrl, makeURLAbsolute } from "./utils";
 import styles from "./LinkEditor.css";
 
 
@@ -75,7 +75,13 @@ export function LinkEditor({ onClose }) {
 
   const onSave = () => {
     if (editedLinkUrl) {
-      editor?.dispatchCommand(TOGGLE_LINK_COMMAND, sanitizeUrl(editedLinkUrl));
+      editor?.dispatchCommand(
+        TOGGLE_LINK_COMMAND,
+        {
+          url: makeURLAbsolute(sanitizeUrl(editedLinkUrl)),
+          target: "_blank",
+        }
+      );
       setLinkUrl(editedLinkUrl);
     }
     onClose();
@@ -102,7 +108,7 @@ export function LinkEditor({ onClose }) {
           <Button
             Icon={GoToLinkLarge}
             disabled={!isEditMode}
-            href={editedLinkUrl || linkUrl}
+            href={makeURLAbsolute(editedLinkUrl || linkUrl)}
             id="open-link-button"
             target="_blank"
             theme="secondaryAlt"

--- a/packages/ui/textEditor/Lexical/components/LinkEditor/utils.js
+++ b/packages/ui/textEditor/Lexical/components/LinkEditor/utils.js
@@ -26,3 +26,7 @@ export function getSelectedNode(selection) {
 export function sanitizeUrl(str) {
   return str.replace(/data:/gi, "").replace(/javascript:/gi, "");
 }
+
+export function makeURLAbsolute(url) {
+  return url.includes("//") ? url : `http://${url}`;
+}

--- a/packages/ui/textEditor/Lexical/components/Toolbar/operations/block.jsx
+++ b/packages/ui/textEditor/Lexical/components/Toolbar/operations/block.jsx
@@ -1,5 +1,6 @@
-import { $getSelection, $isRangeSelection, $createParagraphNode } from "lexical";
-import { $wrapNodes } from "@lexical/selection";
+/* eslint-disable new-cap, camelcase */
+import { $getSelection, $isRangeSelection, $createParagraphNode, DEPRECATED_$isGridSelection } from "lexical";
+import { $setBlocksType } from "@lexical/selection";
 import { $createHeadingNode } from "@lexical/rich-text";
 
 
@@ -8,11 +9,14 @@ export default function operation({ tool, editor }) {
 
   editor.update(() => {
     const selection = $getSelection();
-    if ($isRangeSelection(selection)) {
+    if (
+      $isRangeSelection(selection) ||
+      DEPRECATED_$isGridSelection(selection)
+    ) {
       if (type === "paragraph") {
-        $wrapNodes(selection, () => $createParagraphNode(type));
+        $setBlocksType(selection, () => $createParagraphNode());
       } else {
-        $wrapNodes(selection, () => $createHeadingNode(type));
+        $setBlocksType(selection, () => $createHeadingNode(type));
       }
     }
   });

--- a/packages/ui/textEditor/Lexical/components/Toolbar/operations/format.jsx
+++ b/packages/ui/textEditor/Lexical/components/Toolbar/operations/format.jsx
@@ -1,9 +1,4 @@
-import { $getNearestBlockElementAncestorOrThrow } from "@lexical/utils";
-import { $createTextNode, $getSelection, $isRangeSelection, $isTextNode, PASTE_COMMAND } from "lexical"; import {
-  $isHeadingNode,
-  $isQuoteNode,
-} from "@lexical/rich-text";
-import { $isDecoratorBlockNode } from "@lexical/react/LexicalDecoratorBlockNode";
+import { $getSelection, $isRangeSelection, $isTextNode, PASTE_COMMAND } from "lexical";
 
 
 export default function operation({ tool, editor }) {
@@ -22,7 +17,9 @@ export default function operation({ tool, editor }) {
 
       editor.dispatchCommand(PASTE_COMMAND, event);
     }());
-  } else {
+  }
+
+  if (tool.type === "clearFormatting") {
     editor.update(() => {
       const selection = $getSelection();
       if ($isRangeSelection(selection)) {
@@ -34,28 +31,13 @@ export default function operation({ tool, editor }) {
           return;
         }
 
-        nodes.forEach((node, idx) => {
-          // We split the first and last node by the selection
-          // So that we don't format unselected text inside those nodes
+        nodes.forEach((node) => {
           if ($isTextNode(node)) {
-            if (idx === 0 && anchor.offset !== 0) {
-              node = node.splitText(anchor.offset)[1] || node; //eslint-disable-line
-            }
-            if (idx === nodes.length - 1) {
-              node = node.splitText(focus.offset)[0] || node; //eslint-disable-line
-            }
-
-            if (node.__style !== "") {
-              node.setStyle("");
-            }
-            if (node.__format !== 0) {
-              node.setFormat(0);
-              $getNearestBlockElementAncestorOrThrow(node).setFormat("");
-            }
-          } else if ($isHeadingNode(node) || $isQuoteNode(node)) {
-            node.replace($createTextNode(), true);
-          } else if ($isDecoratorBlockNode(node)) {
-            node.setFormat("");
+            ["bold", "italic", "strikethrough", "underline"].forEach((formatStr) => {
+              if (node.hasFormat(formatStr)) {
+                node.toggleFormat(formatStr);
+              }
+            });
           }
         });
       }

--- a/packages/ui/textEditor/Lexical/components/Toolbar/utils.jsx
+++ b/packages/ui/textEditor/Lexical/components/Toolbar/utils.jsx
@@ -68,6 +68,16 @@ export function checkIfToolIsDisabled(tool, state) {
       return !state.hasSelection;
     case ToolbarItemType.History:
       return !state[tool.type];
+    case ToolbarItemType.List: {
+      const block = state.block ?? "";
+
+      return ["h1", "h2", "h3"].includes(block);
+    }
+    case ToolbarItemType.Block: {
+      const block = state.block ?? "";
+
+      return block === "list";
+    }
     default:
       return false;
   }

--- a/packages/ui/textEditor/Lexical/components/Toolbar/utils.jsx
+++ b/packages/ui/textEditor/Lexical/components/Toolbar/utils.jsx
@@ -5,7 +5,7 @@ import { $isHeadingNode } from "@lexical/rich-text";
 import { $getNearestNodeOfType } from "@lexical/utils";
 
 import IconSet from "../../../../icons/editor";
-import { ToolbarItemType, ToolbarSections } from "../../constants";
+import { ToolbarItem, ToolbarItemType, ToolbarSections } from "../../constants";
 import { getSelectedNode } from "../../utils";
 
 
@@ -77,6 +77,13 @@ export function checkIfToolIsDisabled(tool, state) {
       const block = state.block ?? "";
 
       return block === "list";
+    }
+    case ToolbarItemType.Format: {
+      if (tool.type === ToolbarItem.ClearFormatting) {
+        return !state.hasSelection;
+      }
+
+      return false;
     }
     default:
       return false;

--- a/packages/ui/textEditor/Lexical/components/Warning/index.jsx
+++ b/packages/ui/textEditor/Lexical/components/Warning/index.jsx
@@ -13,7 +13,7 @@ export const Warning = ({ contentLength, minLength, maxLength }) => {
 
   return (
     <div className={styles.editorTextLength}>
-      <span>{`${contentLength} out of a total of ${maxLength} characters (includes html tags)`}</span>
+      <span>{`${contentLength} out of a maximum of ${maxLength} characters (includes html tags)`}</span>
     </div>
   );
 };

--- a/packages/ui/textEditor/Lexical/editor.css
+++ b/packages/ui/textEditor/Lexical/editor.css
@@ -210,3 +210,12 @@
 .input ul ul ol {
   list-style-type: lower-alpha;
 }
+
+.input li:has(ol),
+.input li:has(ul) {
+  list-style: none;
+}
+
+.input li[data-indent] {
+  list-style: none;
+}

--- a/packages/ui/textEditor/Lexical/editor.css
+++ b/packages/ui/textEditor/Lexical/editor.css
@@ -112,3 +112,101 @@
 .editor-listitem {
   margin: calc(1.5 * var(--gridSize)) calc(4 * var(--gridSize)) calc(1.5 * var(--gridSize)) calc(4 * var(--gridSize));
 }
+
+/** Extend `typography.css` `not([class])` styling inside editor input **/
+.input h1 {
+  font-size: var(--typography-XXL-fontSize);
+  line-height: var(--typography-XXL-lineHeight);
+
+  margin: 0 0 calc(7 * var(--gridSize)) 0;
+}
+
+.input h2 {
+  font-size: var(--typography-XL-fontSize);
+  line-height: var(--typography-XL-lineHeight);
+
+  margin: calc(7 * var(--gridSize)) 0 calc(2 * var(--gridSize)) 0;
+}
+
+.input h3 {
+  font-size: var(--typography-L-fontSize);
+  line-height: var(--typography-L-lineHeight);
+
+  margin: calc(5 * var(--gridSize)) 0 calc(2 * var(--gridSize)) 0;
+}
+
+.input h4 {
+  font-size: var(--typography-M-fontSize);
+  line-height: var(--typography-M-lineHeight);
+
+  margin: calc(4 * var(--gridSize)) 0 calc(2 * var(--gridSize)) 0;
+}
+
+.input h5 {
+  font-size: var(--typography-S-fontSize);
+  line-height: var(--typography-S-lineHeight);
+
+  margin: calc(4 * var(--gridSize)) 0 calc(2 * var(--gridSize)) 0;
+
+  text-transform: uppercase;
+}
+
+.input h6 {
+  font-size: var(--typography-S-fontSize);
+  line-height: var(--typography-S-lineHeight);
+
+  margin: calc(4 * var(--gridSize)) 0 calc(2 * var(--gridSize)) 0;
+}
+
+.input h2 + h3,
+.input h2 + h4,
+.input h2 + h5,
+.input h2 + h6,
+.input h3 + h4,
+.input h3 + h5,
+.input h3 + h6,
+.input h4 + h5,
+.input h4 + h6,
+.input h5 + h6 {
+  margin-top: calc(2 * var(--gridSize));
+}
+
+.input p {
+  font-size: var(--typography-M-fontSize);
+  line-height: var(--typography-M-lineHeight);
+
+  margin: 0 0 calc(4 * var(--gridSize)) 0;
+}
+
+.input ul,
+.input ol {
+  font-size: var(--typography-M-fontSize);
+  line-height: var(--typography-M-lineHeight);
+
+  margin: 0 0 calc(4 * var(--gridSize)) 0;
+  padding: 0 0 0 calc(4 * var(--gridSize));
+}
+
+.input p + ul,
+.input p + ol {
+  margin-top: calc(-3 * var(--gridSize));
+}
+
+.input ul ul,
+.input ol ol,
+.input ol ul,
+.input ul ol {
+  margin: 0;
+}
+
+.input ol ol,
+.input ul ol {
+  list-style-type: lower-roman;
+}
+
+.input ol ol ol,
+.input ol ul ol,
+.input ul ol ol,
+.input ul ul ol {
+  list-style-type: lower-alpha;
+}

--- a/packages/ui/textEditor/Lexical/editor.css
+++ b/packages/ui/textEditor/Lexical/editor.css
@@ -57,8 +57,6 @@
 
   overflow: auto;
 
-  max-height: calc(62 * var(--gridSize));
-
   padding: calc(2 * var(--gridSize));
 
   border-top-left-radius: inherit;

--- a/packages/ui/textEditor/Lexical/editor.css
+++ b/packages/ui/textEditor/Lexical/editor.css
@@ -88,6 +88,10 @@
   padding: 0;
 }
 
+.input a {
+  cursor: pointer;
+}
+
 .input:focus {
   box-shadow: none;
 }

--- a/packages/ui/textEditor/Lexical/editor.css
+++ b/packages/ui/textEditor/Lexical/editor.css
@@ -95,11 +95,14 @@
 }
 
 .placeholder {
-  font-size: var(--typography-S-fontSize);
+  font-size: var(--typography-M-fontSize);
+  line-height: inherit;
 
   position: absolute;
 
-  margin: var(--gridSize) calc(var(--gridSize) * 2);
+  margin: calc(2 * var(--gridSize));
+
+  pointer-events: none;
 
   color: var(--color-typography-tertiary);
 }

--- a/packages/ui/textEditor/Lexical/index.jsx
+++ b/packages/ui/textEditor/Lexical/index.jsx
@@ -14,6 +14,7 @@ import { AutoLinkNode, LinkNode } from "@lexical/link";
 import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
+import { TabIndentationPlugin } from "@lexical/react/LexicalTabIndentationPlugin";
 import { TRANSFORMERS } from "@lexical/markdown";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { $generateNodesFromDOM, $generateHtmlFromNodes } from "@lexical/html";
@@ -179,6 +180,7 @@ export function Editor(props) {
       <ListPlugin />
       <LinkPlugin />
       <Toolbar config={toolbarConfig} />
+      <TabIndentationPlugin />
     </div>
     <Warning contentLength={contentLength} maxLength={maxTextLength} minLength={minTextLength} />
   </>);

--- a/packages/ui/textEditor/Lexical/index.jsx
+++ b/packages/ui/textEditor/Lexical/index.jsx
@@ -5,7 +5,6 @@ import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
-import { AutoFocusPlugin } from "@lexical/react/LexicalAutoFocusPlugin";
 import LexicalErrorBoundary from "@lexical/react/LexicalErrorBoundary";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
 import { TableCellNode, TableNode, TableRowNode } from "@lexical/table";
@@ -166,7 +165,6 @@ export function Editor(props) {
         placeholder={<div className={styles.placeholder}>{props.placeholder}</div>}
       />
       <HistoryPlugin />
-      <AutoFocusPlugin />
       <OnChangePlugin ignoreSelectionChange={true} onChange={handleChange} />
 
       <MarkdownShortcutPlugin transformers={TRANSFORMERS} />

--- a/packages/ui/textEditor/Lexical/nodes/CustomTextNode.jsx
+++ b/packages/ui/textEditor/Lexical/nodes/CustomTextNode.jsx
@@ -16,6 +16,36 @@ function wrapElementWith(element, tag) {
   return el;
 }
 
+function wrapContentWith(element, tag) {
+  if (element.tagName === "SPAN") {
+    const el = document.createElement(tag);
+
+    el.innerHTML = element.innerHTML;
+
+    return el;
+  }
+
+  const el = element.cloneNode(false);
+
+  const inner = document.createElement(tag);
+
+  inner.innerHTML = element.innerHTML;
+
+  el.appendChild(inner);
+
+  return el;
+}
+
+function replaceWith(element, tag) {
+  const el = document.createElement(tag);
+
+  Array.prototype.forEach.call(element.childNodes, (child) => {
+    el.appendChild(child);
+  });
+
+  return el;
+}
+
 export class CustomTextNode extends TextNode {
 
   static getType() {
@@ -68,13 +98,22 @@ export class CustomTextNode extends TextNode {
 
     if (element !== null) {
       if (this.hasFormat("strikethrough")) {
-        element = wrapElementWith(element, "s");
+        element = wrapContentWith(element, "s");
       }
       if (this.hasFormat("underline")) {
-        element = wrapElementWith(element, "u");
+        element = wrapContentWith(element, "u");
       }
+
+      if (["STRONG", "BOLD", "B"].includes(element.tagName)) {
+        element = replaceWith(element, "b");
+      }
+
+      if (["EM", "ITALIC", "I"].includes(element.tagName)) {
+        element = replaceWith(element, "i");
+      }
+
       if (this.hasFormat("italic") && this.hasFormat("bold")) {
-        element = wrapElementWith(element, "em");
+        element = wrapElementWith(element, "i");
       }
     }
 

--- a/packages/ui/textEditor/Lexical/nodes/CustomTextNode.jsx
+++ b/packages/ui/textEditor/Lexical/nodes/CustomTextNode.jsx
@@ -98,7 +98,7 @@ export class CustomTextNode extends TextNode {
 
     if (element !== null) {
       if (this.hasFormat("strikethrough")) {
-        element = wrapContentWith(element, "s");
+        element = wrapContentWith(element, "del");
       }
       if (this.hasFormat("underline")) {
         element = wrapContentWith(element, "u");

--- a/packages/ui/textEditor/Lexical/themes/DefaultTheme.js
+++ b/packages/ui/textEditor/Lexical/themes/DefaultTheme.js
@@ -2,6 +2,7 @@ import "./theme.css";
 
 
 const defaultTheme = {
+  root: "root",
   ltr: "ltr",
   rtl: "rtl",
   placeholder: "editor-placeholder",

--- a/packages/ui/textEditor/Lexical/utils.js
+++ b/packages/ui/textEditor/Lexical/utils.js
@@ -22,3 +22,24 @@ export const getSelectedNode = (selection) => {
 
   return $isAtNodeEnd(anchor) ? focusNode : anchorNode;
 };
+
+
+const Processors = {
+  "no-ltr-root": (markup) => markup,
+  "no-paragraph-root": (markup) => markup,
+  "no-inner-span": (markup) => markup.replace(/((<span>)|(<span dir="ltr">))/gm, "").replace(/<\/span>/gm, ""),
+};
+
+export const applyMarkupProcessors = (markup, processorsToRun) => {
+  let newMarkup = markup.slice();
+
+  processorsToRun.forEach((key) => {
+    const processor = Processors[key];
+
+    if (processor) {
+      newMarkup = processor(newMarkup);
+    }
+  });
+
+  return newMarkup;
+};

--- a/stories/lexical/index.stories.mdx
+++ b/stories/lexical/index.stories.mdx
@@ -48,9 +48,15 @@ Users can mark portions or the whole content as paragraphs, headings or emphasis
         console.log("[Text]:", text);
       },[text]);
       return (<div style={{ display: "flex", flexDirection: "column", gap: "18px" }}>
-                <Editor onChange={(e) => {
+                <Editor 
+                  onChange={(e) => {
                   setText(e.target.value);
-                }} value={text} error={error} isSingleRow={singleRow} />
+                  }} 
+                  value={text} 
+                  error={error} 
+                  isSingleRow={singleRow}
+                  placeholder="Type in the editor..."
+                  />
                 <div>
                   <div>Modifiers:</div>
                   <div style={{ display: "flex", flexDirection: "row", gap: "12px" }}>


### PR DESCRIPTION
## Components
### Alerts
 - fixing `persistent` flag not hiding the `Close` alert button when set to `true` in an `alert push`.
 
### Text Editor
 - updating `char limit` warning label text
 - adding `markup` processing to final html output (for now only `span` removal)
 - updating markup wrapping to wrap `u` and `s` nodes as the contents of a node:
   > Markup for example will result in `<sup><u>` as opposed to `<u><sup>`
 - updating editor links to include `_blank` `target` attribute
 - fixed height issue when resizing text editor
 - fixed placeholder styling (font size and lineheight)
 - DOCS: added placeholder value to story
 - disabling `Block` nodes if `List` nodes are selected and vice-versa
 - add cursor pointer to links inside lexical editor
 
 Resolves:
 - https://digital-science.atlassian.net/browse/FIG-23013
- https://digital-science.atlassian.net/browse/FIG-22755
- https://digital-science.atlassian.net/browse/FIG-31092
- https://digital-science.atlassian.net/browse/FIG-31101
- https://digital-science.atlassian.net/browse/FIG-31115
- https://digital-science.atlassian.net/browse/FIG-31114
- https://digital-science.atlassian.net/browse/FIG-31133
- https://digital-science.atlassian.net/browse/FIG-31135
- https://digital-science.atlassian.net/browse/FIG-31125
- https://digital-science.atlassian.net/browse/FIG-22786

- https://digital-science.atlassian.net/browse/FIG-31125
- https://digital-science.atlassian.net/browse/FIG-31135
