### PR TITLE
:rocket: rel-1.3.3

### DIFF
--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@figshare/fcl",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figshare/fcl",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "figshare UI components",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Components
### Alerts
 - fixing `persistent` flag not hiding the `Close` alert button when set to `true` in an `alert push`.
 
### Text Editor
 - updating `char limit` warning label text
 - adding `markup` processing to final html output (for now only `span` removal)
 - updating markup wrapping to wrap `u` and `s` nodes as the contents of a node:
   > Markup for example will result in `<sup><u>` as opposed to `<u><sup>`
 - updating editor links to include `_blank` `target` attribute
 - fixed height issue when resizing text editor
 - fixed placeholder styling (font size and lineheight)
 - DOCS: added placeholder value to story
 - disabling `Block` nodes if `List` nodes are selected and vice-versa
 - add cursor pointer to links inside lexical editor