### PR TITLE
FIG-31282: allow TAB key focus change when editor doesn't have lists

### DIFF
--- a/packages/ui/textEditor/Lexical/constants.js
+++ b/packages/ui/textEditor/Lexical/constants.js
@@ -1,4 +1,13 @@
 export const LowPriority = 1;
+export const HighPriority = 2;
+
+export const FOCUSABLE_ELEMENTS = "button:not([tabindex=\"-1\"]), " +
+"[href]:not([tabindex=\"-1\"]), " +
+"input:not([disabled]):not([tabindex=\"-1\"]), " +
+"select:not([disabled]):not([tabindex=\"-1\"]), " +
+"textarea:not([disabled]):not([tabindex=\"-1\"]), " +
+"[tabindex]:not([tabindex=\"-1\"]), " +
+"div[contenteditable=\"true\"]:not([tabindex=\"-1\"])";
 
 export const ToolbarItem = {
   Heading2: "h2",

--- a/packages/ui/textEditor/Lexical/index.jsx
+++ b/packages/ui/textEditor/Lexical/index.jsx
@@ -25,12 +25,13 @@ import {
   TextNode,
   $createParagraphNode,
   $createTextNode,
+  KEY_TAB_COMMAND,
 } from "lexical";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { mergeRegister } from "@lexical/utils";
 
 import { applyMarkupProcessors, stripHtmlTags } from "./utils";
-import { LowPriority, DefaultToolbarConfig } from "./constants";
+import { LowPriority, HighPriority, DefaultToolbarConfig, FOCUSABLE_ELEMENTS } from "./constants";
 import Toolbar from "./components/Toolbar";
 import { Warning } from "./components/Warning";
 import DefaultTheme from "./themes/DefaultTheme";
@@ -159,6 +160,29 @@ export function Editor(props) {
           onBlur(event);
         }
       }, LowPriority),
+      editor.registerCommand(
+        KEY_TAB_COMMAND,
+        (event) => {
+          if (!event?.target?.querySelector("li")) {
+            event.preventDefault();
+            const focusableElements = Array.prototype.slice.call(document.querySelectorAll(FOCUSABLE_ELEMENTS));
+            const currentFocus = document.activeElement;
+            const currentIndex = focusableElements.indexOf(currentFocus);
+            if (event.shiftKey) {
+              focusableElements[currentIndex - 1].focus();
+
+              return true;
+            }
+
+            focusableElements[currentIndex + 1].focus();
+
+            return true;
+          }
+
+          return false;
+        },
+        HighPriority,
+      ),
     )
   , [editor, callbacks]);
 


### PR DESCRIPTION
[FIG-31282](https://digital-science.atlassian.net/browse/FIG-31282)

[FIG-31282]: https://digital-science.atlassian.net/browse/FIG-31282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ