### PR TITLE
FIG-31380: 'onGoBack' support for 'OverlayHeader'

### DIFF
--- a/packages/ui/overlay/header/overlayHeader.css
+++ b/packages/ui/overlay/header/overlayHeader.css
@@ -10,6 +10,10 @@
   }
 }
 
+.headerInfo {
+  display: flex;
+}
+
 .partOfContent {
   padding: 0 0 calc(6 * var(--gridSize));
 
@@ -39,7 +43,7 @@
   line-height: var(--typography-XL-lineHeight);
 }
 
-.closeButton {
+.iconBtn {
   display: flex;
 
   width: calc(6 * var(--gridSize));

--- a/packages/ui/overlay/header/overlayHeader.jsx
+++ b/packages/ui/overlay/header/overlayHeader.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 
 import { IconButton } from "../../button";
+import ArrowLeftMedium from "../../icons/arrow/left/medium";
 import Cancel from "../../icons/cancel/large";
 import { OverlayContext } from "../overlay";
 
@@ -15,31 +16,37 @@ export default class OverlayHeader extends Component {
   static contextType = OverlayContext;
   static propTypes = {
     /**
-      Optional class name to append to the wrapping node.
+      Optional overlay back button, displayed next to the title.
+      Triggered when the "Go back" header button is clicked.
+     */
+    backBtnFn: PropTypes.func,
+    /**
+     Optional class name to append to the wrapping node.
      */
     className: PropTypes.string,
     /**
-      Optional overlay description, to be displayed under the title.
+     Optional overlay description, to be displayed under the title.
      */
     description: PropTypes.node,
     /**
-      Set this to `true` if you render `OverlayHeader` inside an `OverlayContent` component.
-      It will remove top and side paddings, and appropriately fit as a child of that component.
-      Useful in some cases where we want the OverlayHeader to scroll with the `Content`.
+     Set this to `true` if you render `OverlayHeader` inside an `OverlayContent` component.
+     It will remove top and side paddings, and appropriately fit as a child of that component.
+     Useful in some cases where we want the OverlayHeader to scroll with the `Content`.
      */
     isPartOfContent: PropTypes.bool,
     /**
-      Text or content for the Overlay title.
+     Text or content for the Overlay title.
      */
     title: PropTypes.node,
     /**
      Triggered when the "Close" header button is clicked.
      If not provided, will be inherited from the `Overlay` component context.
-    */
+     */
     onClose: PropTypes.func,
   }
 
   static defaultProps = {
+    backBtnFn: undefined,
     className: undefined,
     description: undefined,
     isPartOfContent: false,
@@ -48,7 +55,7 @@ export default class OverlayHeader extends Component {
   }
 
   render() {
-    const { className, isPartOfContent, description, title, onClose, ...props } = this.props;
+    const { backBtnFn, className, isPartOfContent, description, title, onClose, ...props } = this.props;
     const overlayId = this.context?.id ?? 0;
     const isForConfirmationOverlay = CONFIRMATION_OVERLAYS.includes(this.context?.background);
     const ariaTitle = `dialog-${overlayId}-title`;
@@ -62,16 +69,29 @@ export default class OverlayHeader extends Component {
           [styles.confirmation]: isForConfirmationOverlay,
         }, className)}
       >
-        <div>
-          <h1 className={styles.title} id={ariaTitle}>{title}</h1>
-          {description && <p className={styles.description} id={ariaDescription}>{description}</p>}
+        <div className={styles.headerInfo}>
+          {backBtnFn && (
+            <IconButton
+              Icon={ArrowLeftMedium}
+              className={styles.iconBtn}
+              size="M"
+              tabIndex={-1}
+              theme="tertiary"
+              onClick={backBtnFn}
+            >
+              Go back
+            </IconButton>)}
+          <div>
+            <h1 className={styles.title} id={ariaTitle}>{title}</h1>
+            {description && <p className={styles.description} id={ariaDescription}>{description}</p>}
+          </div>
         </div>
         <IconButton
           Icon={Cancel}
-          className={styles.closeButton}
+          className={styles.iconBtn}
           size="M"
           tabIndex={-1}
-          theme="primary"
+          theme="tertiary"
           onClick={onClose ?? this.context.onClose}
         >
           Close


### PR DESCRIPTION
[FIG-31380](https://digital-science.atlassian.net/browse/FIG-31380)

<img width="887" alt="Screenshot 2023-07-18 at 14 02 33" src="https://github.com/figshare/fcl/assets/63391401/4ad5d2ae-313d-48e1-8c3a-ee3029080341">


[FIG-31380]: https://digital-science.atlassian.net/browse/FIG-31380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ