### PR TITLE
FIG-31397, FIG-31531, FIG-31223: fix missing text formatting when pasting from google docs

### DIFF
--- a/packages/ui/textEditor/Lexical/components/Toolbar/commands.jsx
+++ b/packages/ui/textEditor/Lexical/components/Toolbar/commands.jsx
@@ -8,6 +8,7 @@ import { $isLinkNode, $isAutoLinkNode } from "@lexical/link";
 
 import { getSelectedNode } from "../../utils";
 import { LinkEditor } from "../LinkEditor/LinkEditor";
+import { createPasteEventWithData, parsePastedLexicalContent } from "../../../utils/parsingUtils";
 
 
 export function defineClickCommandListener({ showModal }) {
@@ -39,4 +40,24 @@ export function defineUndoRedoCommandListeners({ dispatch, type }) {
 
     return false;
   };
+}
+
+export function definePasteCommand(event) {
+  const pastedText = event.clipboardData?.getData("text/html");
+  let processedText = pastedText;
+
+  if (pastedText?.includes("&lt;")) {
+    const doc = new DOMParser().parseFromString(pastedText, "text/html");
+    processedText = doc.body.textContent;
+  }
+
+  if (pastedText?.includes("text-decoration:underline line-through;")) {
+    processedText = parsePastedLexicalContent(processedText);
+  }
+
+  if (processedText !== pastedText) {
+    return createPasteEventWithData(processedText);
+  }
+
+  return false;
 }

--- a/packages/ui/textEditor/Lexical/constants.js
+++ b/packages/ui/textEditor/Lexical/constants.js
@@ -1,4 +1,5 @@
 export const LowPriority = 1;
+export const HighPriority = 3;
 
 export const ToolbarItem = {
   Heading2: "h2",

--- a/packages/ui/textEditor/Lexical/index.jsx
+++ b/packages/ui/textEditor/Lexical/index.jsx
@@ -27,18 +27,20 @@ import {
   FOCUS_COMMAND,
   KEY_TAB_COMMAND,
   INDENT_CONTENT_COMMAND,
+  PASTE_COMMAND,
   TextNode,
 } from "lexical";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { mergeRegister } from "@lexical/utils";
 
 import { applyMarkupProcessors, stripHtmlTags } from "./utils";
-import { LowPriority, DefaultToolbarConfig } from "./constants";
+import { LowPriority, HighPriority, DefaultToolbarConfig } from "./constants";
 import Toolbar from "./components/Toolbar";
 import { Warning } from "./components/Warning";
 import DefaultTheme from "./themes/DefaultTheme";
 import styles from "./editor.css"; // eslint-disable-line css-modules/no-unused-class
 import { CustomTextNode } from "./nodes/CustomTextNode";
+import { definePasteCommand } from "./components/Toolbar/commands";
 
 
 export const DEFAULT_MAX_TEXT_LENGTH = 10000;
@@ -192,6 +194,20 @@ export function Editor(props) {
 
         return true;
       }, LowPriority),
+      editor.registerCommand(
+        PASTE_COMMAND,
+        (event) => {
+          event.preventDefault();
+          if (definePasteCommand(event)) {
+            editor.dispatchCommand(PASTE_COMMAND, definePasteCommand(event));
+
+            return true;
+          }
+
+          return false;
+        },
+        HighPriority,
+      ),
     )
   , [editor, callbacks]);
 
@@ -230,7 +246,7 @@ export function Editor(props) {
       <LinkPlugin />
       <Toolbar config={toolbarConfig} />
     </div>
-    <Warning contentLength={contentLength} maxLength={maxTextLength} minLength={minTextLength} />
+    {!isSingleRow && <Warning contentLength={contentLength} maxLength={maxTextLength} minLength={minTextLength} /> }
   </>);
 }
 

--- a/packages/ui/textEditor/utils/parsingUtils.js
+++ b/packages/ui/textEditor/utils/parsingUtils.js
@@ -177,3 +177,38 @@ export const parsePastedContent = (editorState, html = "") => {
 
   return EditorState.push(editorState, newContent, "insert-characters");
 };
+
+/* istanbul ignore next */
+export const parsePastedLexicalContent = (html = "") => {
+
+  const parsedHtmlChunk = html.split("</span>").map((chunk) => {
+    if (chunk.includes(STRIKE_THROUGH_UNDERLINE)) {
+      const parser = new DOMParser();
+      const element = parser.parseFromString(chunk, "text/html");
+      const text = (element.getElementsByTagName("span") || [])[0].innerText;
+
+      return chunk.
+        replace(STRIKE_THROUGH_UNDERLINE, "").
+        replace(
+          `white-space:pre-wrap;">${text}`,
+          `white-space:pre-wrap;"><u><s>${text}</s></u>`
+        );
+    }
+
+    return chunk;
+  });
+
+  return parsedHtmlChunk.join("</span>");
+};
+
+export const createPasteEventWithData = (data) => {
+  const event = new Event("paste", {
+    bubbles: true,
+    cancelable: true,
+  });
+
+  event.clipboardData = new DataTransfer();
+  event.clipboardData.setData("text/html", data);
+
+  return event;
+};


### PR DESCRIPTION
[FIG-31397](https://digital-science.atlassian.net/browse/FIG-31397)
[FIG-31223](https://digital-science.atlassian.net/browse/FIG-31223)
[FIG-31531](https://digital-science.atlassian.net/browse/FIG-31531)
<img width="814" alt="Screenshot 2023-07-19 at 13 11 01" src="https://github.com/figshare/fcl/assets/14940318/7f29fc2b-2dae-426e-b003-d3e11701dcba">


[FIG-31397]: https://digital-science.atlassian.net/browse/FIG-31397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FIG-31223]: https://digital-science.atlassian.net/browse/FIG-31223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FIG-31531]: https://digital-science.atlassian.net/browse/FIG-31531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ