### PR TITLE
FIG-31397: fix substring and superstring losing Google docs format/styling

### DIFF
--- a/packages/ui/textEditor/Lexical/editor.css
+++ b/packages/ui/textEditor/Lexical/editor.css
@@ -48,11 +48,14 @@
 }
 
 .container.singleRow {
+  height: auto;
   min-height: calc(12 * var(--gridSize));
 }
 
 .input {
   overflow: auto;
+
+  height: 100%;
 
   border-top-left-radius: inherit;
   border-top-right-radius: inherit;


### PR DESCRIPTION
[FIG-31397](https://digital-science.atlassian.net/browse/FIG-31397)

[FIG-31397]: https://digital-science.atlassian.net/browse/FIG-31397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ