### PR TITLE
FIG-23141: hide pasteWithoutFormat button on firefox

### DIFF
--- a/packages/ui/textEditor/Lexical/components/Toolbar/index.jsx
+++ b/packages/ui/textEditor/Lexical/components/Toolbar/index.jsx
@@ -9,7 +9,7 @@ import {
 } from "lexical";
 import { mergeRegister } from "@lexical/utils";
 
-import { DefaultToolbarConfig, LowPriority } from "../../constants";
+import { DefaultToolbarConfig, LowPriority, ToolbarItem } from "../../constants";
 import useModal from "../LinkEditor/useModal";
 
 import styles from "./Toolbar.css"; // eslint-disable-line css-modules/no-unused-class
@@ -109,20 +109,26 @@ function renderToolbarSections(sectioned, onToolSelect, state) {
     {sectioned.order.map(((sectionKey, index, list) => {
       const section = sectioned.sections[sectionKey];
       const notLast = index !== list.length - 1;
-
+      const isFirefox = navigator.userAgent.indexOf("Firefox") > -1;
       const { type, tools } = section;
 
       return (
         <React.Fragment key={type}>
-          {tools.map((tool) => (
-            <Tool
-              key={`${tool.group}-${tool.type}`}
-              active={checkIfToolIsActive(tool, state)}
-              disabled={checkIfToolIsDisabled(tool, state)}
-              {...tool}
-              onToolSelect={onToolSelect}
-            />
-          ))}
+          {tools.map((tool) => {
+            if (tool.type === ToolbarItem.PasteWithoutFormat && isFirefox) {
+              return null;
+            }
+
+            return (
+              <Tool
+                key={`${tool.group}-${tool.type}`}
+                active={checkIfToolIsActive(tool, state)}
+                disabled={checkIfToolIsDisabled(tool, state)}
+                {...tool}
+                onToolSelect={onToolSelect}
+              />
+            );
+          })}
           {notLast && <Divider />}
         </React.Fragment>
       );

--- a/packages/ui/textEditor/Lexical/editor.css
+++ b/packages/ui/textEditor/Lexical/editor.css
@@ -48,8 +48,10 @@
 }
 
 .container.singleRow {
-  height: auto;
-  min-height: calc(12 * var(--gridSize));
+  overflow-y: scroll;
+
+  height: calc(14 * var(--gridSize));
+  min-height: calc(14 * var(--gridSize));
 }
 
 .input {


### PR DESCRIPTION
[FIG-23141](https://digital-science.atlassian.net/browse/FIG-23141)

[FIG-23141]: https://digital-science.atlassian.net/browse/FIG-23141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ