### PR TITLE
FIG-32560: fix tooltip still showing when focus is lost without blur trigger

### DIFF
--- a/packages/ui/button/genericButton/index.jsx
+++ b/packages/ui/button/genericButton/index.jsx
@@ -214,8 +214,10 @@ export default class GenericButton extends PureComponent {
 
   onFocus = (event) => {
     this.focusTimeoutId = setTimeout(() => {
-      this.setState({ popperKey: this.state.popperKey + 1 });
-      this.showTooltip();
+      if (event.target === document.activeElement) {
+        this.setState({ popperKey: this.state.popperKey + 1 });
+        this.showTooltip();
+      }
     }, 100);
     this.props.onFocus?.(event);
   }


### PR DESCRIPTION
[FIG-32560](https://digital-science.atlassian.net/browse/FIG-32560)

[FIG-32560]: https://digital-science.atlassian.net/browse/FIG-32560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ