### PR TITLE
FIG-32882: show tooltips for back and close only on subsequent key tabthroughs

### DIFF
--- a/packages/ui/button/genericButton/index.jsx
+++ b/packages/ui/button/genericButton/index.jsx
@@ -58,11 +58,11 @@ export default class GenericButton extends PureComponent {
      */
     onLongPress: PropTypes.func,
     /**
-      Called when the user hovers into the button's visible/clip area
+      Called when the user hovers out-of the button's visible/clip area
      */
     onMouseOut: PropTypes.func,
     /**
-      Called when the user hovers out-of the button's visible/clip area
+      Called when the user hovers into the button's visible/clip area
      */
     onMouseOver: PropTypes.func,
   }

--- a/packages/ui/overlay/header/overlayHeader.jsx
+++ b/packages/ui/overlay/header/overlayHeader.jsx
@@ -43,6 +43,11 @@ export default class OverlayHeader extends Component {
      If not provided, will be inherited from the `Overlay` component context.
      */
     onClose: PropTypes.func,
+    /**
+     Triggered when the "Go Back" header button is clicked.
+     If not provided, the button will not be shown.
+     */
+    onGoBack: PropTypes.func,
   }
 
   static defaultProps = {
@@ -51,15 +56,20 @@ export default class OverlayHeader extends Component {
     description: undefined,
     isPartOfContent: false,
     title: undefined,
+    onGoBack: undefined,
     onClose: undefined,
   }
 
+  state = { firstFocusIn: true }
+
   render() {
-    const { backBtnFn, className, isPartOfContent, description, title, onClose, ...props } = this.props;
+    const { backBtnFn, className, isPartOfContent, description, title, onClose, onGoBack, ...props } = this.props;
+    const { firstFocusIn } = this.state;
     const overlayId = this.context?.id ?? 0;
     const isForConfirmationOverlay = CONFIRMATION_OVERLAYS.includes(this.context?.background);
     const ariaTitle = `dialog-${overlayId}-title`;
     const ariaDescription = `dialog-${overlayId}-description`;
+    const onGoBackFn = backBtnFn || onGoBack;
 
     return (
       <div
@@ -70,15 +80,17 @@ export default class OverlayHeader extends Component {
         }, className)}
       >
         <div className={styles.headerInfo}>
-          {backBtnFn && (
+          {onGoBackFn && (
             <IconButton
               Icon={ArrowLeftMedium}
               className={styles.iconBtn}
               size="M"
               theme="tertiary"
-              onClick={backBtnFn}
+              onBlur={this.onFirstFocus}
+              onClick={onGoBackFn}
+              onMouseEnter={this.onFirstFocus}
             >
-              Go back
+              {firstFocusIn ? undefined : "Go back"}
             </IconButton>)}
           <div>
             <h1 className={styles.title} id={ariaTitle}>{title}</h1>
@@ -90,11 +102,17 @@ export default class OverlayHeader extends Component {
           className={styles.iconBtn}
           size="M"
           theme="tertiary"
+          onBlur={this.onFirstFocus}
           onClick={onClose ?? this.context.onClose}
+          onMouseEnter={this.onFirstFocus}
         >
-          Close
+          {firstFocusIn ? undefined : "Close"}
         </IconButton>
       </div>
     );
+  }
+
+  onFirstFocus = () => {
+    this.setState({ firstFocusIn: false });
   }
 }

--- a/packages/ui/overlay/header/overlayHeader.test.jsx
+++ b/packages/ui/overlay/header/overlayHeader.test.jsx
@@ -92,4 +92,63 @@ describe("<OverlayHeader />", () => {
     expect(onClose).toHaveBeenCalled();
     component.unmount();
   });
+
+  it("should render a Go Back button if backBtnFn is provided", () => {
+    const onClose = jest.fn();
+    const onGoBack = jest.fn();
+    const component = shallow(
+      <OverlayHeader
+        backBtnFn={onGoBack}
+        description="Description"
+        title="Title"
+        onClose={onClose}
+      />);
+
+    expect(component.find(IconButton)).toHaveLength(2);
+    component.find(IconButton).at(0).simulate("click");
+    expect(onGoBack).toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    component.unmount();
+  });
+
+  it("should not show tooltips on first focus of back or close buttons", () => {
+    let component = shallow(
+      <OverlayHeader
+        description="Description"
+        title="Title"
+        onClose={jest.fn()}
+        onGoBack={jest.fn()}
+      />);
+
+    expect(component.state().firstFocusIn).toEqual(true);
+
+    let button = component.find(IconButton).at(0);
+    expect(button.props().children).toBe(undefined);
+    button.simulate("blur");
+
+    expect(component.state().firstFocusIn).toEqual(false);
+    component.update();
+
+    expect(component.find(IconButton).at(0).props().children).toBe("Go back");
+
+    component = shallow(
+      <OverlayHeader
+        description="Description"
+        title="Title"
+        onClose={jest.fn()}
+        onGoBack={jest.fn()}
+      />);
+
+    expect(component.state().firstFocusIn).toEqual(true);
+    expect(button.props().children).toBe(undefined);
+
+
+    button = component.find(IconButton).at(1);
+    button.simulate("blur");
+
+    expect(component.state().firstFocusIn).toEqual(false);
+    component.update();
+
+    expect(component.find(IconButton).at(1).props().children).toBe("Close");
+  });
 });


### PR DESCRIPTION
resolves: https://digital-science.atlassian.net/browse/FIG-32882

Updated `OverlayHeader` `Back` and `Close` buttons to not have a tooltip for the first time they are `focused` (programmaticaly or by tab-through). Allow `mouse` tooltips always, and after the user returns to the buttons through key navigation.