### PR TITLE
FIG-32972: Embargo overlay accessibility issues

### DIFF
--- a/packages/ui/input/date/index.jsx
+++ b/packages/ui/input/date/index.jsx
@@ -151,6 +151,7 @@ export default class Date extends Component {
 
     return (
       <ReactDatepicker
+        key={this.datepicker?.state?.open}
         ref={this.setRef}
         placeholderText={placeholder ?? dateFormat.toUpperCase()}
         {...rest}
@@ -270,8 +271,7 @@ export default class Date extends Component {
       return;
     }
 
-    if (event.target === this.datepicker?.input && !this.datepicker.isCalendarOpen()) {
-
+    if (event.target === this.datepicker?.input && !this.datepicker.isCalendarOpen() && event.relatedTarget) {
       this.datepicker.setOpen(true);
     }
   }
@@ -324,7 +324,9 @@ export default class Date extends Component {
         this.datepicker.setOpen(!this.datepicker.isCalendarOpen());
         break;
       case "Escape":
-        this.datepicker.input?.focus?.();
+        setTimeout(() => {
+          this.datepicker.input?.focus?.();
+        }, FOCUS_DELAY);
         break;
       default:
         break;


### PR DESCRIPTION
[FIG-32972](https://digital-science.atlassian.net/browse/FIG-32972)

4. Sending ESCAPE in date selector input multiple times doesn’t close the overlay. After using ESCAPE to close the date picker, the focus is lost and we need to press TAB (SHIFT + TAB) to regain the focus and be able to close the overlay. Same for Private link overlay


https://github.com/figshare/fcl/assets/63391401/7eb3d0cd-d7da-4f36-927f-4e5adcf81986



[FIG-32972]: https://digital-science.atlassian.net/browse/FIG-32972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ