### PR TITLE
:rocket: rel-1.3.30

### DIFF
--- a/packages/ui/package-lock.json
+++ b/packages/ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@figshare/fcl",
-  "version": "1.3.29",
+  "version": "1.3.30",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@figshare/fcl",
-  "version": "1.3.29",
+  "version": "1.3.30",
   "description": "figshare UI components",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Components
### TextEditor
 - fixed a prop type warning for `lockRTL` property passed to the textarea dom node.
 - fixed a style for some break nodes in paragraphs.