### PR TITLE
FIG-35295 add text label for button and search input

### DIFF
--- a/packages/ui/button/genericButton/base.css
+++ b/packages/ui/button/genericButton/base.css
@@ -1,3 +1,13 @@
 .disableUserSelection {
   user-select: none;
 }
+
+.label {
+  position: absolute;
+
+  visibility: hidden;
+  overflow: hidden;
+
+  width: 0;
+  height: 0;
+}

--- a/packages/ui/button/genericButton/base.jsx
+++ b/packages/ui/button/genericButton/base.jsx
@@ -9,6 +9,7 @@ const longPressDelay = 500;
 
 export default class Base extends PureComponent {
   static propTypes = {
+    children: PropTypes.any,
     disabled: PropTypes.bool,
     href: PropTypes.string,
     innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
@@ -17,6 +18,7 @@ export default class Base extends PureComponent {
     style: PropTypes.object,
     target: PropTypes.string,
     type: PropTypes.oneOf(["button", "reset", "submit"]),
+    value: PropTypes.string,
     onClick: PropTypes.func,
     onLongPress: PropTypes.func,
     onTouchCancel: PropTypes.func,
@@ -26,6 +28,7 @@ export default class Base extends PureComponent {
   }
 
   static defaultProps = {
+    children: undefined,
     disabled: false,
     href: undefined,
     innerRef: null,
@@ -34,6 +37,7 @@ export default class Base extends PureComponent {
     style: undefined,
     target: undefined,
     type: "button",
+    value: undefined,
     onClick: undefined,
     onLongPress: undefined,
     onTouchCancel: undefined,
@@ -61,7 +65,11 @@ export default class Base extends PureComponent {
   }
 
   render() {
-    const { disabled, href, normalizeHref, innerRef, rel, target, type, onLongPress, ...props } = this.props;
+    const {
+      disabled, href, normalizeHref, innerRef, rel, target, type,
+      onLongPress, children, value,
+      ...props
+    } = this.props;
     const BaseComponent = !href ? "button" : "a";
 
     return (
@@ -71,7 +79,20 @@ export default class Base extends PureComponent {
         {...this.computeProps()}
         aria-disabled={disabled || undefined}
         onClick={this.onClick}
-      />
+      >
+        {children}
+        {this.renderValue(value)}
+      </BaseComponent>
+    );
+  }
+
+  renderValue(value) {
+    if (!value) {
+      return null;
+    }
+
+    return (
+      <span className={styles.label}>{value}</span>
     );
   }
 

--- a/packages/ui/input/search/index.css
+++ b/packages/ui/input/search/index.css
@@ -137,3 +137,12 @@
     margin: calc(1.5 * var(--gridSize)) calc(2 * var(--gridSize));
   }
 }
+
+.label {
+  position: absolute;
+
+  visibility: hidden;
+
+  width: 0;
+  height: 0;
+}

--- a/packages/ui/input/search/index.jsx
+++ b/packages/ui/input/search/index.jsx
@@ -32,6 +32,15 @@ export default class SearchInput extends PureComponent {
      */
     error: PropTypes.bool,
     /**
+     Identifier value for the input.
+     */
+    id: PropTypes.string,
+    /**
+     Semantic label contents for the search input.
+     If undefined, the label will not be rendered.
+     */
+    label: PropTypes.string,
+    /**
      Search action http method.
      */
     method: PropTypes.string,
@@ -62,6 +71,8 @@ export default class SearchInput extends PureComponent {
     className: undefined,
     disabled: false,
     error: false,
+    id: undefined,
+    label: "Search",
     method: "get",
     size: "S",
     theme: "default",
@@ -73,7 +84,7 @@ export default class SearchInput extends PureComponent {
   state = { isInputFocused: false }
 
   render() {
-    const { className, disabled, error, method, size, theme, action, onSubmit, ...props } = this.props;
+    const { className, disabled, error, label, method, size, theme, action, onSubmit, ...props } = this.props;
     const { isInputFocused } = this.state;
     const SubmitIcon = iconSizes.submit[size];
 
@@ -94,6 +105,7 @@ export default class SearchInput extends PureComponent {
         role="search"
         onSubmit={onSubmit}
       >
+        {label ? (<label className={styles.label} htmlFor={props.id}>{label}</label>) : null}
         <input
           {...props}
           aria-disabled={disabled || undefined}


### PR DESCRIPTION
## Button (Base)
 - added `value` property, that once provided, will render a visually hidden text node inside the button with the text contents of the property. Useful to provide text content to a button where it's visual content has no text (eg IconButton).
 
 ## SearchInput
  - added a `<label` element linked to the `<input` `id`. Id needs to be provided to not `orphan` this new label.