### PR TITLE
FIG-35526: fix `description` empty paragraphs having margin-bottom

### DIFF
--- a/packages/ui/styles/generic/typography.css
+++ b/packages/ui/styles/generic/typography.css
@@ -152,3 +152,7 @@ a:hover > sup,
 a:focus > sup {
   text-decoration: underline;
 }
+
+p[data-br-only="true"] {
+  margin: 0 !important;
+}


### PR DESCRIPTION
[FIG-35526](https://digital-science.atlassian.net/browse/FIG-35526)

[FIG-35526]: https://digital-science.atlassian.net/browse/FIG-35526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ