### PR TITLE
FIG-35540: fixing issue with loadable/component ssr enabled

### DIFF
--- a/packages/ui/helpers/renderInPortal.jsx
+++ b/packages/ui/helpers/renderInPortal.jsx
@@ -6,7 +6,7 @@ import ReactDOM from "react-dom";
 export default class RenderInPortal extends Component {
   static propTypes = {
     children: PropTypes.any.isRequired,
-    portalNode: PropTypes.instanceOf(HTMLElement),
+    portalNode: PropTypes.any,
   }
 
   static defaultProps = { portalNode: undefined }

--- a/packages/ui/textEditor/Lexical/components/Warning/index.jsx
+++ b/packages/ui/textEditor/Lexical/components/Warning/index.jsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { number } from "prop-types";
 
-import { DEFAULT_MAX_TEXT_LENGTH, DEFAULT_MIN_TEXT_LENGTH } from "../../index";
-
 import styles from "./Warning.css";
 
 
@@ -21,6 +19,6 @@ export const Warning = ({ contentLength, minLength, maxLength }) => {
 Warning.propTypes = { contentLength: number, maxLength: number, minLength: number };
 Warning.defaultProps = {
   contentLength: 0,
-  minLength: DEFAULT_MIN_TEXT_LENGTH,
-  maxLength: DEFAULT_MAX_TEXT_LENGTH,
+  minLength: 5000,
+  maxLength: 10000,
 };

--- a/packages/ui/textEditor/Lexical/index.jsx
+++ b/packages/ui/textEditor/Lexical/index.jsx
@@ -106,36 +106,6 @@ function populateEditorState(value) {
   };
 }
 
-export default function EditorContainer(props) {
-  const { disabled, onError, onBlur } = props;
-
-  const initialConfig = useMemo(() => {
-    return { ...defaultConfig, editable: !disabled, onError, editorState: populateEditorState(props.value) };
-  }, [defaultConfig, onError, disabled]);
-
-  const containerRef = useRef(null);
-
-  const handleBlur = useCallback((event) => {
-    if (!containerRef.current.contains(event.relatedTarget)) {
-      if (typeof onBlur === "function") {
-        onBlur(event);
-      }
-    }
-  }, [onBlur]);
-
-  return (
-    <div
-      ref={containerRef}
-      role="presentation"
-      onBlur={handleBlur}
-    >
-      <LexicalComposer initialConfig={initialConfig} >
-        <Editor {...props} />
-      </LexicalComposer>
-    </div>
-  );
-}
-
 export function Editor(props) {
   const {
     onBlur,
@@ -273,6 +243,37 @@ export function Editor(props) {
   </>);
 }
 
+export function EditorContainer(props) {
+  const { disabled, onError, onBlur } = props;
+
+  const initialConfig = useMemo(() => {
+    return { ...defaultConfig, editable: !disabled, onError, editorState: populateEditorState(props.value) };
+  }, [defaultConfig, onError, disabled]);
+
+  const containerRef = useRef(null);
+
+  const handleBlur = useCallback((event) => {
+    if (!containerRef.current.contains(event.relatedTarget)) {
+      if (typeof onBlur === "function") {
+        onBlur(event);
+      }
+    }
+  }, [onBlur]);
+
+  return (
+    <div
+      ref={containerRef}
+      role="presentation"
+      onBlur={handleBlur}
+    >
+      <LexicalComposer initialConfig={initialConfig} >
+        <Editor {...props} />
+      </LexicalComposer>
+    </div>
+  );
+}
+
+
 EditorContainer.propTypes = {
   /**
     Callback called when the editor contents are edited or changed.
@@ -376,3 +377,5 @@ EditorContainer.defaultProps = {
 };
 
 Editor.propTypes = EditorContainer.propTypes; // eslint-disable-line
+
+export default EditorContainer;


### PR DESCRIPTION
resolves issue with `@loadable/component` srr imports not being resolved when `stripHtmlTags` or `RenderInPortal` is imported.