### PR TITLE
FIG-45512: dropdown onToggle triggered on uncaptured clicks

### DIFF
--- a/packages/ui/dropdown/Dropdown.jsx
+++ b/packages/ui/dropdown/Dropdown.jsx
@@ -95,17 +95,19 @@ export default class Dropdown extends Component {
     return { context: { ...context, toggleNode: node } };
   });
 
-  onToggle = (event, forceVisible = null) => {
+  onToggle = (event, modifiers) => {
     const { isVisible, onToggle } = this.props;
+    const forcedVisibility = typeof modifiers === "object" && typeof modifiers?.isVisible === "boolean";
+    const forcedIsVisibleValue = forcedVisibility ? modifiers.isVisible : null;
 
-    if (forceVisible && activeDropdownInstance && activeDropdownInstance !== this) {
+    if (forcedIsVisibleValue && activeDropdownInstance && activeDropdownInstance !== this) {
       activeDropdownInstance.props.onToggle(event, { isVisible: false });
     }
 
     // react-17 propagation fix
     event?.stopPropagation?.();
 
-    onToggle(event, { isVisible: forceVisible !== null ? forceVisible : !isVisible });
+    onToggle(event, { isVisible: forcedVisibility ? forcedIsVisibleValue : !isVisible });
   };
 
   onKeyDown = (event) => {
@@ -120,7 +122,7 @@ export default class Dropdown extends Component {
           this.focusSelectableNeighbour(target, -1);
         } else {
           this._focusLast = true;
-          this.onToggle(event, true);
+          this.onToggle(event, { isVisible: true });
         }
 
         break;
@@ -131,7 +133,7 @@ export default class Dropdown extends Component {
           this.focusSelectableNeighbour(target, 1);
         } else {
           this._focusLast = false;
-          this.onToggle(event, true);
+          this.onToggle(event, { isVisible: true });
         }
 
         break;
@@ -152,7 +154,7 @@ export default class Dropdown extends Component {
       case "Escape":
       case "Tab":
         if (isVisible) {
-          this.onToggle(event, false);
+          this.onToggle(event, { isVisible: false });
         }
 
         break;

--- a/packages/ui/dropdown/Menu/Menu.jsx
+++ b/packages/ui/dropdown/Menu/Menu.jsx
@@ -82,7 +82,7 @@ export class DropdownMenu extends Component {
   onClose = (event) => {
     const { onToggle } = this.props.dropdownContext;
 
-    onToggle(event, false);
+    onToggle(event, { isVisible: false });
   }
 
   getBoundary = () => {

--- a/packages/ui/dropdown/index.jsx
+++ b/packages/ui/dropdown/index.jsx
@@ -1,4 +1,4 @@
 export { default as Dropdown } from "./Dropdown";
-export { default as UncontrolledDropdown } from "./Dropdown";
+export { UncontrolledDropdown } from "./Dropdown";
 export { Menu } from "./Menu";
 export { Toggle } from "./Toggle";

--- a/packages/ui/helpers/rootCloseListener.jsx
+++ b/packages/ui/helpers/rootCloseListener.jsx
@@ -67,11 +67,17 @@ export default class RootCloseListener extends Component {
     const ownNode = this.containerNode;
     const currentNode = event.target;
 
+    // mark the next click as captured in this handler.
+    // the onClick handler should only take into consideration clicks that were not captured here.
+    // it should disregard others as they might have been stopped from propagating and this.preventClose
+    // would not have a correctly parsed value.
+    this.captured = true;
     this.preventClose = hasModifierKeys || !isLeftClick || contains(currentNode, ownNode);
   }
 
   onClick = (event) => {
-    if (!this.preventClose) {
+    if (!this.preventClose && this.captured) {
+      this.captured = false;
       this.props.onClose(event);
     }
   }

--- a/packages/ui/helpers/rootCloseListener.jsx
+++ b/packages/ui/helpers/rootCloseListener.jsx
@@ -67,9 +67,9 @@ export default class RootCloseListener extends Component {
     const ownNode = this.containerNode;
     const currentNode = event.target;
 
-    // mark the next click as captured in this handler.
-    // the onClick handler should only take into consideration clicks that were not captured here.
-    // it should disregard others as they might have been stopped from propagating and this.preventClose
+    // Mark the next click as having been captured in this handler.
+    // The onClick handler should only take into consideration clicks that were captured here.
+    // It should disregard others as they might have been stopped from propagating and this.preventClose
     // would not have a correctly parsed value.
     this.captured = true;
     this.preventClose = hasModifierKeys || !isLeftClick || contains(currentNode, ownNode);


### PR DESCRIPTION
resolves FIG-45512.

## Components
### Dropdown
 - resolved onClose being called for clicks that were not handled in the capture phase by rootCloseListener
 - resolved UncontrolledDropdown import pointing to Dropdown.